### PR TITLE
BI-6536 Adding a wrapper class for ch logger and updating tests

### DIFF
--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/common/ApplicationLogger.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/common/ApplicationLogger.java
@@ -1,0 +1,68 @@
+package uk.gov.companieshouse.chipsrestinterfacesconsumer.common;
+
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.chipsrestinterfacesconsumer.Application;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Acts as a wrapper for the structured logger to help with unit testing and also ensures that the
+ * map data structure passed to the Companies House logger is not changed if used by subsequent
+ * logging calls.
+ */
+@Component
+public class ApplicationLogger {
+    private static final Logger LOGGER = LoggerFactory.getLogger(Application.APPLICATION_NAME);
+
+    public void debugContext(String context, String message) {
+        LOGGER.debugContext(context, message, null);
+    }
+
+    public void debugContext(String context, String message, Map<String, Object> dataMap) {
+        LOGGER.debugContext(context, message, cloneMapData(dataMap));
+    }
+
+    public void info(String message) {
+        LOGGER.info(message, null);
+    }
+
+    public void infoContext(String context, String message) {
+        LOGGER.infoContext(context, message, null);
+    }
+
+    public void infoContext(String context, String message, Map<String, Object> dataMap) {
+        LOGGER.infoContext(context, message, cloneMapData(dataMap));
+    }
+
+    public void errorContext(String context, Exception e) {
+        LOGGER.errorContext(context, e, null);
+    }
+
+    public void errorContext(String context, String message, Exception e) {
+        LOGGER.errorContext(context, message, e, null);
+    }
+
+    public void errorContext(String context, String message, Exception e, Map<String, Object> dataMap) {
+        LOGGER.errorContext(context, message, e, cloneMapData(dataMap));
+    }
+
+    public void error(String message, Exception e, Map<String, Object> dataMap) {
+        LOGGER.error(message, e, cloneMapData(dataMap));
+    }
+
+    /**
+     * The Companies House logging implementation modifies the data map content which means that
+     * if the same data map is used for subsequent calls any new message that might be passed in
+     * is not displayed in certain log format outputs. Creating a clone of the data map gets around
+     * this issue.
+     *
+     * @param dataMap The map data to log
+     * @return A cloned copy of the map data
+     */
+    private Map<String, Object> cloneMapData(Map<String, Object> dataMap) {
+        return new HashMap<>(dataMap);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/common/ApplicationLogger.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/common/ApplicationLogger.java
@@ -4,7 +4,6 @@ import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.Application;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
-
 import java.util.HashMap;
 import java.util.Map;
 

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/IncomingMessageConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/IncomingMessageConsumer.java
@@ -7,7 +7,6 @@ import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogge
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.model.ChipsKafkaMessage;
 import uk.gov.companieshouse.kafka.consumer.CHConsumer;
 import uk.gov.companieshouse.kafka.message.Message;
-
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import java.io.IOException;

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/IncomingMessageConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/IncomingMessageConsumer.java
@@ -3,12 +3,10 @@ package uk.gov.companieshouse.chipsrestinterfacesconsumer.consumer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import uk.gov.companieshouse.chipsrestinterfacesconsumer.Application;
+import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.model.ChipsKafkaMessage;
 import uk.gov.companieshouse.kafka.consumer.CHConsumer;
 import uk.gov.companieshouse.kafka.message.Message;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
@@ -22,7 +20,8 @@ import java.util.Map;
 @Component
 public class IncomingMessageConsumer implements MessageConsumer {
 
-    private static final Logger logger = LoggerFactory.getLogger(Application.APPLICATION_NAME);
+    @Autowired
+    private ApplicationLogger logger;
 
     @Autowired
     private CHConsumer consumer;
@@ -43,7 +42,7 @@ public class IncomingMessageConsumer implements MessageConsumer {
         for (Message msg : consumer.consume()) {
             try {
                 logger.info(msg.toString());
-                receivedList.add(deserialise(msg));
+                receivedList.add(deserialize(msg));
             } catch (Exception e) {
                 Map<String, Object> data = new HashMap<>();
                 data.put("message", msg.getValue() == null ? "" : new String(msg.getValue()));
@@ -53,7 +52,7 @@ public class IncomingMessageConsumer implements MessageConsumer {
         return receivedList;
     }
 
-    ChipsKafkaMessage deserialise(Message msg) throws IOException {
+    private ChipsKafkaMessage deserialize(Message msg) throws IOException {
         ObjectMapper objectMapper = new ObjectMapper();
         return objectMapper.readValue(msg.getValue(), ChipsKafkaMessage.class);
     }

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/common/ApplicationLoggerTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/common/ApplicationLoggerTest.java
@@ -1,0 +1,56 @@
+package uk.gov.companieshouse.chipsrestinterfacesconsumer.common;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+class ApplicationLoggerTest {
+
+    private static final String CONTEXT = "CONTEXT";
+    private static final String TEST_MESSAGE = "TEST";
+    private static final String LOG_MAP_KEY = "COMPANY_NUMBER";
+    private static final String LOG_MAP_VALUE = "00006400";
+
+    @InjectMocks
+    private static ApplicationLogger apiLogger;
+
+    private Map<String, Object> logMap;
+
+    @BeforeEach
+    void setup() {
+        logMap = new HashMap<>();
+        logMap.put(LOG_MAP_KEY, LOG_MAP_VALUE);
+    }
+
+    @Test
+    void testDebugContextLoggingDoesNotModifyLogMap() {
+        apiLogger.debugContext(CONTEXT, TEST_MESSAGE, logMap);
+
+        assertEquals(1, logMap.size());
+        assertEquals(LOG_MAP_VALUE, logMap.get(LOG_MAP_KEY));
+    }
+
+    @Test
+    void testInfoContextLoggingDoesNotModifyLogMap() {
+        apiLogger.infoContext(CONTEXT, TEST_MESSAGE, logMap);
+
+        assertEquals(1, logMap.size());
+        assertEquals(LOG_MAP_VALUE, logMap.get(LOG_MAP_KEY));
+    }
+
+    @Test
+    void testErrorContextLoggingDoesNotModifyLogMap() {
+        apiLogger.errorContext(CONTEXT, TEST_MESSAGE, new Exception(TEST_MESSAGE), logMap);
+
+        assertEquals(1, logMap.size());
+        assertEquals(LOG_MAP_VALUE, logMap.get(LOG_MAP_KEY));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/common/ApplicationLoggerTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/common/ApplicationLoggerTest.java
@@ -20,7 +20,7 @@ class ApplicationLoggerTest {
     private static final String LOG_MAP_VALUE = "00006400";
 
     @InjectMocks
-    private static ApplicationLogger apiLogger;
+    private static ApplicationLogger applicationLogger;
 
     private Map<String, Object> logMap;
 
@@ -32,7 +32,7 @@ class ApplicationLoggerTest {
 
     @Test
     void testDebugContextLoggingDoesNotModifyLogMap() {
-        apiLogger.debugContext(CONTEXT, TEST_MESSAGE, logMap);
+        applicationLogger.debugContext(CONTEXT, TEST_MESSAGE, logMap);
 
         assertEquals(1, logMap.size());
         assertEquals(LOG_MAP_VALUE, logMap.get(LOG_MAP_KEY));
@@ -40,7 +40,7 @@ class ApplicationLoggerTest {
 
     @Test
     void testInfoContextLoggingDoesNotModifyLogMap() {
-        apiLogger.infoContext(CONTEXT, TEST_MESSAGE, logMap);
+        applicationLogger.infoContext(CONTEXT, TEST_MESSAGE, logMap);
 
         assertEquals(1, logMap.size());
         assertEquals(LOG_MAP_VALUE, logMap.get(LOG_MAP_KEY));
@@ -48,9 +48,42 @@ class ApplicationLoggerTest {
 
     @Test
     void testErrorContextLoggingDoesNotModifyLogMap() {
-        apiLogger.errorContext(CONTEXT, TEST_MESSAGE, new Exception(TEST_MESSAGE), logMap);
+        applicationLogger.errorContext(CONTEXT, TEST_MESSAGE, new Exception(TEST_MESSAGE), logMap);
 
         assertEquals(1, logMap.size());
         assertEquals(LOG_MAP_VALUE, logMap.get(LOG_MAP_KEY));
+    }
+
+    @Test
+    void testErrorNoContextLoggingDoesNotModifyLogMap() {
+        applicationLogger.error(TEST_MESSAGE, new Exception(TEST_MESSAGE), logMap);
+
+        assertEquals(1, logMap.size());
+        assertEquals(LOG_MAP_VALUE, logMap.get(LOG_MAP_KEY));
+    }
+
+    @Test
+    void testDebugContext() {
+        applicationLogger.debugContext(CONTEXT, TEST_MESSAGE);
+    }
+
+    @Test
+    void testInfo() {
+        applicationLogger.info(TEST_MESSAGE);
+    }
+
+    @Test
+    void testInfoContext() {
+        applicationLogger.infoContext(CONTEXT, TEST_MESSAGE);
+    }
+
+    @Test
+    void testErrorContextNoMessage() {
+        applicationLogger.errorContext(CONTEXT, new Exception());
+    }
+
+    @Test
+    void testErrorContext() {
+        applicationLogger.errorContext(CONTEXT, TEST_MESSAGE, new Exception());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/common/ApplicationLoggerTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/common/ApplicationLoggerTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import java.util.HashMap;
 import java.util.Map;
 

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/common/ApplicationLoggerTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/common/ApplicationLoggerTest.java
@@ -9,6 +9,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(MockitoExtension.class)
@@ -64,26 +65,26 @@ class ApplicationLoggerTest {
 
     @Test
     void testDebugContext() {
-        applicationLogger.debugContext(CONTEXT, TEST_MESSAGE);
+        assertDoesNotThrow(() -> applicationLogger.debugContext(CONTEXT, TEST_MESSAGE));
     }
 
     @Test
     void testInfo() {
-        applicationLogger.info(TEST_MESSAGE);
+        assertDoesNotThrow(() -> applicationLogger.info(TEST_MESSAGE));
     }
 
     @Test
     void testInfoContext() {
-        applicationLogger.infoContext(CONTEXT, TEST_MESSAGE);
+        assertDoesNotThrow(() -> applicationLogger.infoContext(CONTEXT, TEST_MESSAGE));
     }
 
     @Test
     void testErrorContextNoMessage() {
-        applicationLogger.errorContext(CONTEXT, new Exception());
+        assertDoesNotThrow(() -> applicationLogger.errorContext(CONTEXT, new Exception()));
     }
 
     @Test
     void testErrorContext() {
-        applicationLogger.errorContext(CONTEXT, TEST_MESSAGE, new Exception());
+        assertDoesNotThrow(() -> applicationLogger.errorContext(CONTEXT, TEST_MESSAGE, new Exception()));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/common/ApplicationLoggerTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/common/ApplicationLoggerTest.java
@@ -2,16 +2,12 @@ package uk.gov.companieshouse.chipsrestinterfacesconsumer.common;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@ExtendWith(MockitoExtension.class)
 class ApplicationLoggerTest {
 
     private static final String CONTEXT = "CONTEXT";
@@ -19,13 +15,13 @@ class ApplicationLoggerTest {
     private static final String LOG_MAP_KEY = "COMPANY_NUMBER";
     private static final String LOG_MAP_VALUE = "00006400";
 
-    @InjectMocks
-    private static ApplicationLogger applicationLogger;
+    private ApplicationLogger applicationLogger;
 
     private Map<String, Object> logMap;
 
     @BeforeEach
     void setup() {
+        applicationLogger = new ApplicationLogger();
         logMap = new HashMap<>();
         logMap.put(LOG_MAP_KEY, LOG_MAP_VALUE);
     }

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/IncomingMessageConsumerUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/IncomingMessageConsumerUnitTest.java
@@ -2,34 +2,49 @@ package uk.gov.companieshouse.chipsrestinterfacesconsumer.consumer;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.model.ChipsKafkaMessage;
 import uk.gov.companieshouse.kafka.consumer.CHConsumer;
 import uk.gov.companieshouse.kafka.message.Message;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class IncomingMessageConsumerUnitTest {
 
+    private final static String ERROR_MESSAGE = "Failed to read message from queue";
+    private final static String LOG_MESSAGE_KEY = "message";
+
+    @Mock
+    private ApplicationLogger logger;
+
     @Mock
     private CHConsumer consumer;
 
     @InjectMocks
     private IncomingMessageConsumer incomingMessageConsumer;
+
+    @Captor
+    private ArgumentCaptor<Map<String, Object>> loggingDataMapCaptor;
 
     @Test
     void initialisationTest() {
@@ -47,7 +62,9 @@ class IncomingMessageConsumerUnitTest {
     void testReadNoMessage() {
         List<Message> messages = Collections.emptyList();
         when(consumer.consume()).thenReturn(messages);
+
         Collection<ChipsKafkaMessage> result = incomingMessageConsumer.read();
+
         assertTrue(result.isEmpty());
     }
 
@@ -59,23 +76,31 @@ class IncomingMessageConsumerUnitTest {
         message.setValue("{}".getBytes());
         messages.add(message);
         when(consumer.consume()).thenReturn(messages);
+
         Collection<ChipsKafkaMessage> result = incomingMessageConsumer.read();
+
         assertEquals(1, result.size());
         assertNotNull(result.iterator().next());
     }
 
     @Test
     void testDeserializeExceptionIsCaught() {
+        String messageValue = "bad message";
         List<Message> messages = new ArrayList<>();
         Message message = new Message();
-        message.setValue("bad message".getBytes());
+        message.setValue(messageValue.getBytes());
         messages.add(message);
         when(consumer.consume()).thenReturn(messages);
 
         incomingMessageConsumer.read();
-        assertThatThrownBy(() -> incomingMessageConsumer.deserialise(message))
-                .isInstanceOf(IOException.class);
-        // TODO mock logger (autowire it in class being tested) and verify it is called when exception caught in read()
+
+        verify(logger, times(1)).info(anyString());
+        verify(logger, times(1)).error(
+                eq(ERROR_MESSAGE),
+                any(Exception.class),
+                loggingDataMapCaptor.capture());
+        Map<String, Object> loggingDataMap = loggingDataMapCaptor.getValue();
+        assertEquals(messageValue, loggingDataMap.get(LOG_MESSAGE_KEY));
     }
 
     @Test
@@ -87,8 +112,12 @@ class IncomingMessageConsumerUnitTest {
         when(consumer.consume()).thenReturn(messages);
 
         incomingMessageConsumer.read();
-        assertThatThrownBy(() -> incomingMessageConsumer.deserialise(message))
-                .isInstanceOf(IllegalArgumentException.class);
-        // TODO mock logger (autowire it in class being tested) and verify it is called when exception caught in read()
+        verify(logger, times(1)).info(anyString());
+        verify(logger, times(1)).error(
+                eq(ERROR_MESSAGE),
+                any(Exception.class),
+                loggingDataMapCaptor.capture());
+        Map<String, Object> loggingDataMap = loggingDataMapCaptor.getValue();
+        assertEquals("", loggingDataMap.get(LOG_MESSAGE_KEY));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/IncomingMessageConsumerUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/IncomingMessageConsumerUnitTest.java
@@ -11,7 +11,6 @@ import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogge
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.model.ChipsKafkaMessage;
 import uk.gov.companieshouse.kafka.consumer.CHConsumer;
 import uk.gov.companieshouse.kafka.message.Message;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/model/ChipsKafkaMessageUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/model/ChipsKafkaMessageUnitTest.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.chipsrestinterfacesconsumer.model;
 
 import org.junit.jupiter.api.Test;
-
 import java.time.LocalDateTime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
The ch logger requires a new map for each call that uses a map, so created a wrapper for it to create a new map when needed. Updated the unit tests.