### PR TITLE
Use correct content type for posting to chips rest

### DIFF
--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/IncomingMessageConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/IncomingMessageConsumer.java
@@ -49,7 +49,7 @@ public class IncomingMessageConsumer implements MessageConsumer {
                 ChipsRestInterfacesSend deserializedMsg = deserialize(msg);
                 logger.info("Deserialised message", Collections.singletonMap("Message", deserializedMsg));
                 messageProcessorService.processMessage(deserializedMsg);
-                logger.info(String.format("Message %s processed, committing offset", msg.getKey()));
+                logger.info(String.format("Message %s processed, committing offset", msg.getOffset()));
                 consumer.commit(msg);
             } catch (Exception e) {
                 Map<String, Object> data = new HashMap<>();

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/client/ChipsRestClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/client/ChipsRestClientTest.java
@@ -7,12 +7,16 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriTemplate;
 import uk.gov.companieshouse.chips.ChipsRestInterfacesSend;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger;
 
-import java.util.Map;
+import java.net.URI;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
@@ -25,8 +29,7 @@ class ChipsRestClientTest {
     private static final String CHIPS_REST_HOST = "hostname/";
     private static final String CHIPS_REST_ENDPOINT = "test-endpoint";
     private static final String DATA = "data";
-    private static final String CHIPS_REST_ENDPOINT_URI_VAR_PLACEHOLDER = "{chips-rest-endpoint}";
-    private static final String CHIPS_REST_ENDPOINT_URI_VAR = "chips-rest-endpoint";
+    private static final URI FULL_EXPANDED_CHIPS_REST_URL = new UriTemplate(CHIPS_REST_HOST+CHIPS_REST_ENDPOINT).expand();
 
     @Mock
     private RestTemplate restTemplate;
@@ -38,10 +41,7 @@ class ChipsRestClientTest {
     private ChipsRestClient chipsRestClient;
 
     @Captor
-    private ArgumentCaptor<String> messageDataArgCaptor;
-
-    @Captor
-    private ArgumentCaptor<Map<String, String>> uriVariablesArgCaptor;
+    private ArgumentCaptor<HttpEntity<String>> messageDataArgCaptor;
 
     @Test
     void sendToChipsTest() {
@@ -52,14 +52,14 @@ class ChipsRestClientTest {
         chipsRestClient.init();
         chipsRestClient.sendToChips(chipsRestInterfacesSend);
 
-        verify(restTemplate, times(1)).postForEntity(
-                eq(CHIPS_REST_HOST + CHIPS_REST_ENDPOINT_URI_VAR_PLACEHOLDER), messageDataArgCaptor.capture(),
-                eq(String.class), uriVariablesArgCaptor.capture());
+        verify(restTemplate, times(1)).exchange(
+                eq(FULL_EXPANDED_CHIPS_REST_URL), eq(HttpMethod.POST), messageDataArgCaptor.capture(),
+                eq(String.class)
+        );
 
         var messageData = messageDataArgCaptor.getValue();
-        var uriVariables = uriVariablesArgCaptor.getValue();
 
-        assertEquals(DATA, messageData);
-        assertEquals(CHIPS_REST_ENDPOINT, uriVariables.get(CHIPS_REST_ENDPOINT_URI_VAR));
+        assertEquals(DATA, messageData.getBody());
+        assertEquals(MediaType.APPLICATION_JSON, messageData.getHeaders().getContentType());
     }
 }


### PR DESCRIPTION
Specifically set content type to JSON.
And manually expand the URI to include the Uri variables.

Also changed to using offset in commit log message as key was returning as null