### PR TITLE
bi 6580 run consumers in seperate threads

### DIFF
--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/Application.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/Application.java
@@ -5,22 +5,24 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import uk.gov.companieshouse.chipsrestinterfacesconsumer.consumer.MessageConsumer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import uk.gov.companieshouse.chipsrestinterfacesconsumer.service.LoopingMessageProcessor;
+
+import java.util.concurrent.CompletableFuture;
 
 @SpringBootApplication
+@EnableAsync
 public class Application implements CommandLineRunner {
 
     public static final String APPLICATION_NAME = "chips-rest-interfaces-consumer";
 
     @Autowired
-    @Qualifier("incoming-message-consumer")
-    private MessageConsumer incomingMessageConsumer;
+    @Qualifier("main-looping-consumer")
+    private LoopingMessageProcessor loopingMainMessageConsumer;
 
     @Autowired
-    @Qualifier("retry-message-consumer")
-    private MessageConsumer retryMessageConsumer;
-
-    private boolean isRunning = true;
+    @Qualifier("retry-looping-consumer")
+    private LoopingMessageProcessor loopingRetryMessageConsumer;
 
     public static void main(String[] args) {
         SpringApplication.run(Application.class);
@@ -28,9 +30,10 @@ public class Application implements CommandLineRunner {
 
     @Override
     public void run(String... args) {
-        while(isRunning) {
-            incomingMessageConsumer.readAndProcess();
-            retryMessageConsumer.readAndProcess();
-        }
+        var mainCompletableFuture = loopingMainMessageConsumer.loopReadAndProcess();
+        var retryCompletableFuture = loopingRetryMessageConsumer.loopReadAndProcess();
+
+        // Wait until they are all done
+        CompletableFuture.allOf(mainCompletableFuture, retryCompletableFuture).join();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/MultiThreadedConfig.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/MultiThreadedConfig.java
@@ -1,0 +1,41 @@
+package uk.gov.companieshouse.chipsrestinterfacesconsumer.configuration;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger;
+import uk.gov.companieshouse.chipsrestinterfacesconsumer.consumer.MessageConsumer;
+import uk.gov.companieshouse.chipsrestinterfacesconsumer.service.LoopingMessageProcessor;
+import uk.gov.companieshouse.chipsrestinterfacesconsumer.service.impl.LoopingMessageProcessorServiceImpl;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+public class MultiThreadedConfig {
+
+    @Bean("main-looping-consumer")
+    LoopingMessageProcessor mainLoopingConsumer(ApplicationLogger logger,
+                                                @Qualifier("incoming-message-consumer") MessageConsumer messageConsumer
+    ) {
+        return new LoopingMessageProcessorServiceImpl(messageConsumer, logger, "main-looping-consumer");
+    }
+
+    @Bean("retry-looping-consumer")
+    LoopingMessageProcessor retryLoopingConsumer(ApplicationLogger logger,
+                                                 @Qualifier("retry-message-consumer") MessageConsumer messageConsumer
+    ) {
+        return new LoopingMessageProcessorServiceImpl(messageConsumer, logger, "retry-looping-consumer");
+    }
+
+    @Bean
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(2);
+        executor.setQueueCapacity(500);
+        executor.setThreadNamePrefix("KafkaConsumer-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/MultiThreadedConfig.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/MultiThreadedConfig.java
@@ -12,7 +12,7 @@ import uk.gov.companieshouse.chipsrestinterfacesconsumer.service.impl.LoopingMes
 import java.util.concurrent.Executor;
 
 @Configuration
-public class MultiThreadedConfig {
+class MultiThreadedConfig {
 
     @Bean("main-looping-consumer")
     LoopingMessageProcessor mainLoopingConsumer(ApplicationLogger logger,
@@ -34,7 +34,7 @@ public class MultiThreadedConfig {
         executor.setCorePoolSize(2);
         executor.setMaxPoolSize(2);
         executor.setQueueCapacity(500);
-        executor.setThreadNamePrefix("KafkaConsumer-");
+        executor.setThreadNamePrefix("CRICMessageProcessor-");
         executor.initialize();
         return executor;
     }

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/MultiThreadedConfig.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/MultiThreadedConfig.java
@@ -29,7 +29,7 @@ public class MultiThreadedConfig {
     }
 
     @Bean
-    public Executor taskExecutor() {
+    Executor taskExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(2);
         executor.setMaxPoolSize(2);

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/LoopingMessageProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/LoopingMessageProcessor.java
@@ -1,0 +1,7 @@
+package uk.gov.companieshouse.chipsrestinterfacesconsumer.service;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface LoopingMessageProcessor {
+    CompletableFuture<Boolean> loopReadAndProcess();
+}

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/LoopingMessageProcessorServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/LoopingMessageProcessorServiceImpl.java
@@ -1,0 +1,42 @@
+package uk.gov.companieshouse.chipsrestinterfacesconsumer.service.impl;
+
+import org.springframework.scheduling.annotation.Async;
+import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger;
+import uk.gov.companieshouse.chipsrestinterfacesconsumer.consumer.MessageConsumer;
+import uk.gov.companieshouse.chipsrestinterfacesconsumer.service.LoopingMessageProcessor;
+
+import javax.annotation.PreDestroy;
+import java.util.concurrent.CompletableFuture;
+
+public class LoopingMessageProcessorServiceImpl implements LoopingMessageProcessor {
+
+    private final MessageConsumer consumer;
+    private final ApplicationLogger logger;
+    private final String id;
+    private boolean isRunning = true;
+
+    public LoopingMessageProcessorServiceImpl(MessageConsumer consumer, ApplicationLogger logger, String id) {
+        this.consumer = consumer;
+        this.logger = logger;
+        this.id = id;
+    }
+
+    @PreDestroy
+    void preDestroy() {
+        isRunning = false;
+    }
+
+    @Async
+    @Override
+    public CompletableFuture<Boolean> loopReadAndProcess() {
+        logger.info(String.format("%s - Read and process loop starting", id));
+        while (isRunning) {
+            this.consumer.readAndProcess();
+            // ToDo Throttle
+        }
+
+        logger.info(String.format("%s - Read and process loop ended", id));
+
+        return CompletableFuture.completedFuture(true);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/MultiThreadedConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/MultiThreadedConfigTest.java
@@ -1,0 +1,19 @@
+package uk.gov.companieshouse.chipsrestinterfacesconsumer.configuration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MultiThreadedConfigTest {
+
+    @Test
+    void taskExecutorTest() {
+        MultiThreadedConfig multiThreadedConfig = new MultiThreadedConfig();
+
+        var executor = (ThreadPoolTaskExecutor) multiThreadedConfig.taskExecutor();
+        assertEquals(2, executor.getMaxPoolSize());
+        assertEquals(2, executor.getCorePoolSize());
+        assertEquals("CRICMessageProcessor-", executor.getThreadNamePrefix());
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/LoopingMessageProcessorServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/LoopingMessageProcessorServiceImplTest.java
@@ -9,6 +9,8 @@ import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.consumer.MessageConsumer;
 
+import java.util.concurrent.ExecutionException;
+
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doAnswer;
@@ -35,7 +37,7 @@ class LoopingMessageProcessorServiceImplTest {
     }
 
     @Test
-    void loopReadAndProcessTest() {
+    void loopReadAndProcessTest() throws ExecutionException, InterruptedException {
         doAnswer(invocation -> {
             ReflectionTestUtils.setField(loopingMessageProcessorService, "isRunning", false);
             return null;
@@ -45,5 +47,6 @@ class LoopingMessageProcessorServiceImplTest {
                 loopingMessageProcessorService.loopReadAndProcess();
 
         verify(messageConsumer, times(1)).readAndProcess();
+        assertTrue(loopingMessageProcessorServiceResult.get());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/LoopingMessageProcessorServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/LoopingMessageProcessorServiceImplTest.java
@@ -9,6 +9,8 @@ import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.consumer.MessageConsumer;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -26,7 +28,14 @@ class LoopingMessageProcessorServiceImplTest {
     private LoopingMessageProcessorServiceImpl loopingMessageProcessorService;
 
     @Test
-    void loopReadAndProcess() {
+    void preDestroyTest() {
+        assertTrue((Boolean) ReflectionTestUtils.getField(loopingMessageProcessorService, "isRunning"));
+        loopingMessageProcessorService.preDestroy();
+        assertFalse((Boolean) ReflectionTestUtils.getField(loopingMessageProcessorService, "isRunning"));
+    }
+
+    @Test
+    void loopReadAndProcessTest() {
         doAnswer(invocation -> {
             ReflectionTestUtils.setField(loopingMessageProcessorService, "isRunning", false);
             return null;

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/LoopingMessageProcessorServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/LoopingMessageProcessorServiceImplTest.java
@@ -1,0 +1,40 @@
+package uk.gov.companieshouse.chipsrestinterfacesconsumer.service.impl;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger;
+import uk.gov.companieshouse.chipsrestinterfacesconsumer.consumer.MessageConsumer;
+
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class LoopingMessageProcessorServiceImplTest {
+
+    @Mock
+    private ApplicationLogger logger;
+
+    @Mock
+    private MessageConsumer messageConsumer;
+
+    @InjectMocks
+    private LoopingMessageProcessorServiceImpl loopingMessageProcessorService;
+
+    @Test
+    void loopReadAndProcess() {
+        doAnswer(invocation -> {
+            ReflectionTestUtils.setField(loopingMessageProcessorService, "isRunning", false);
+            return null;
+        }).when(messageConsumer).readAndProcess();
+
+        var loopingMessageProcessorServiceResult =
+                loopingMessageProcessorService.loopReadAndProcess();
+
+        verify(messageConsumer, times(1)).readAndProcess();
+    }
+}


### PR DESCRIPTION
Run the main and retry consumers in seperate threads to allow them to execute in parallel