### PR TITLE
Allow the app to be started in error processing mode

### DIFF
--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/Application.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/Application.java
@@ -33,7 +33,7 @@ public class Application implements CommandLineRunner {
     private ApplicationLogger logger;
 
     @Value("${RUN_APP_IN_ERROR_MODE:false}")
-    private boolean isErrorConsumer;
+    private boolean runAppInErrorMode;
 
     public static void main(String[] args) {
         SpringApplication.run(Application.class);
@@ -41,7 +41,7 @@ public class Application implements CommandLineRunner {
 
     @Override
     public void run(String... args) {
-        if (!isErrorConsumer) {
+        if (!runAppInErrorMode) {
             logger.info(String.format("%s started in normal processing mode", APPLICATION_NAME));
             var mainCompletableFuture = loopingMainMessageConsumer.loopReadAndProcess();
             var retryCompletableFuture = loopingRetryMessageConsumer.loopReadAndProcess();

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/Application.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/Application.java
@@ -32,7 +32,7 @@ public class Application implements CommandLineRunner {
     @Autowired
     private ApplicationLogger logger;
 
-    @Value("${IS_ERROR_CONSUMER}")
+    @Value("${IS_ERROR_CONSUMER:false}")
     private boolean isErrorConsumer;
 
     public static void main(String[] args) {

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/Application.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/Application.java
@@ -32,7 +32,7 @@ public class Application implements CommandLineRunner {
     @Autowired
     private ApplicationLogger logger;
 
-    @Value("${IS_ERROR_CONSUMER:false}")
+    @Value("${RUN_APP_IN_ERROR_MODE:false}")
     private boolean isErrorConsumer;
 
     public static void main(String[] args) {

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/Application.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/Application.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.scheduling.annotation.EnableAsync;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.service.LoopingMessageProcessor;
@@ -19,10 +20,12 @@ public class Application implements CommandLineRunner {
     public static final String APPLICATION_NAME = "chips-rest-interfaces-consumer";
 
     @Autowired
+    @Lazy
     @Qualifier("main-looping-consumer")
     private LoopingMessageProcessor loopingMainMessageConsumer;
 
     @Autowired
+    @Lazy
     @Qualifier("retry-looping-consumer")
     private LoopingMessageProcessor loopingRetryMessageConsumer;
 

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/Application.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/Application.java
@@ -2,10 +2,12 @@ package uk.gov.companieshouse.chipsrestinterfacesconsumer;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableAsync;
+import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.service.LoopingMessageProcessor;
 
 import java.util.concurrent.CompletableFuture;
@@ -24,16 +26,29 @@ public class Application implements CommandLineRunner {
     @Qualifier("retry-looping-consumer")
     private LoopingMessageProcessor loopingRetryMessageConsumer;
 
+    @Autowired
+    private ApplicationLogger logger;
+
+    @Value("${IS_ERROR_CONSUMER}")
+    private boolean isErrorConsumer;
+
     public static void main(String[] args) {
         SpringApplication.run(Application.class);
     }
 
     @Override
     public void run(String... args) {
-        var mainCompletableFuture = loopingMainMessageConsumer.loopReadAndProcess();
-        var retryCompletableFuture = loopingRetryMessageConsumer.loopReadAndProcess();
+        if (!isErrorConsumer) {
+            logger.info(String.format("%s started in normal processing mode", APPLICATION_NAME));
+            var mainCompletableFuture = loopingMainMessageConsumer.loopReadAndProcess();
+            var retryCompletableFuture = loopingRetryMessageConsumer.loopReadAndProcess();
 
-        // Wait until they are all done
-        CompletableFuture.allOf(mainCompletableFuture, retryCompletableFuture).join();
+            // Wait until they are all done
+            CompletableFuture.allOf(mainCompletableFuture, retryCompletableFuture).join();
+        } else {
+            logger.info(String.format("%s started in error processing mode", APPLICATION_NAME));
+
+            //ToDo Start error consumer
+        }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/ApplicationConfig.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/ApplicationConfig.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.consumer.MessageConsumer;
@@ -21,6 +22,7 @@ class ApplicationConfig {
     }
 
     @Bean("incoming-message-consumer")
+    @Lazy
     MessageConsumer incomingMessageConsumer(ApplicationLogger logger,
                                             MessageProcessorService messageProcessorService,
                                             DeserializerFactory deserializerFactory,
@@ -34,6 +36,7 @@ class ApplicationConfig {
     }
 
     @Bean("retry-message-consumer")
+    @Lazy
     MessageConsumer retryMessageConsumer(ApplicationLogger logger,
                                          MessageProcessorService messageProcessorService,
                                          DeserializerFactory deserializerFactory,

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/KafkaConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/KafkaConfiguration.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.chipsrestinterfacesconsumer.configuration;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import uk.gov.companieshouse.kafka.consumer.CHKafkaConsumerGroup;
 import uk.gov.companieshouse.kafka.consumer.ConsumerConfig;
 import uk.gov.companieshouse.kafka.deserialization.DeserializerFactory;
@@ -42,6 +43,7 @@ class KafkaConfiguration {
     }
 
     @Bean("incoming-consumer-group")
+    @Lazy
     CHKafkaConsumerGroup getIncomingConsumer() {
         return new CHKafkaConsumerGroup(getIncomingConsumerConfig());
     }
@@ -56,6 +58,7 @@ class KafkaConfiguration {
     }
 
     @Bean("retry-consumer-group")
+    @Lazy
     CHKafkaConsumerGroup getRetryConsumer() {
         return new CHKafkaConsumerGroup(getRetryConsumerConfig());
     }

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/MultiThreadedConfig.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/MultiThreadedConfig.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.chipsrestinterfacesconsumer.configuration;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.consumer.MessageConsumer;
@@ -15,6 +16,7 @@ import java.util.concurrent.Executor;
 class MultiThreadedConfig {
 
     @Bean("main-looping-consumer")
+    @Lazy
     LoopingMessageProcessor mainLoopingConsumer(ApplicationLogger logger,
                                                 @Qualifier("incoming-message-consumer") MessageConsumer messageConsumer
     ) {
@@ -22,6 +24,7 @@ class MultiThreadedConfig {
     }
 
     @Bean("retry-looping-consumer")
+    @Lazy
     LoopingMessageProcessor retryLoopingConsumer(ApplicationLogger logger,
                                                  @Qualifier("retry-message-consumer") MessageConsumer messageConsumer
     ) {

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/ApplicationTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/ApplicationTest.java
@@ -1,0 +1,53 @@
+package uk.gov.companieshouse.chipsrestinterfacesconsumer;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger;
+import uk.gov.companieshouse.chipsrestinterfacesconsumer.service.LoopingMessageProcessor;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ApplicationTest {
+
+    @Mock
+    private ApplicationLogger logger;
+
+    @Mock
+    private LoopingMessageProcessor loopingMainMessageConsumer;
+
+    @Mock
+    private LoopingMessageProcessor loopingRetryMessageConsumer;
+
+    @InjectMocks
+    private Application application;
+
+    @Test
+    void runErrorProcessingTrueTest() {
+        ReflectionTestUtils.setField(application, "isErrorConsumer", true);
+        application.run();
+
+        verify(loopingMainMessageConsumer, times(0)).loopReadAndProcess();
+        verify(loopingRetryMessageConsumer, times(0)).loopReadAndProcess();
+    }
+
+    @Test
+    void runErrorProcessingFalseTest() {
+        when(loopingMainMessageConsumer.loopReadAndProcess()).thenReturn(CompletableFuture.completedFuture(true));
+        when(loopingRetryMessageConsumer.loopReadAndProcess()).thenReturn(CompletableFuture.completedFuture(true));
+
+        ReflectionTestUtils.setField(application, "isErrorConsumer", false);
+        application.run();
+
+        verify(loopingMainMessageConsumer, times(1)).loopReadAndProcess();
+        verify(loopingRetryMessageConsumer, times(1)).loopReadAndProcess();
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/ApplicationTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/ApplicationTest.java
@@ -32,7 +32,7 @@ class ApplicationTest {
 
     @Test
     void runErrorProcessingTrueTest() {
-        ReflectionTestUtils.setField(application, "isErrorConsumer", true);
+        ReflectionTestUtils.setField(application, "runAppInErrorMode", true);
         application.run();
 
         verify(loopingMainMessageConsumer, times(0)).loopReadAndProcess();
@@ -46,7 +46,7 @@ class ApplicationTest {
         when(loopingMainMessageConsumer.loopReadAndProcess()).thenReturn(CompletableFuture.completedFuture(true));
         when(loopingRetryMessageConsumer.loopReadAndProcess()).thenReturn(CompletableFuture.completedFuture(true));
 
-        ReflectionTestUtils.setField(application, "isErrorConsumer", false);
+        ReflectionTestUtils.setField(application, "runAppInErrorMode", false);
         application.run();
 
         verify(loopingMainMessageConsumer, times(1)).loopReadAndProcess();

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/ApplicationTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/ApplicationTest.java
@@ -37,6 +37,8 @@ class ApplicationTest {
 
         verify(loopingMainMessageConsumer, times(0)).loopReadAndProcess();
         verify(loopingRetryMessageConsumer, times(0)).loopReadAndProcess();
+
+        //ToDo Ensure error consumer is called
     }
 
     @Test
@@ -49,5 +51,7 @@ class ApplicationTest {
 
         verify(loopingMainMessageConsumer, times(1)).loopReadAndProcess();
         verify(loopingRetryMessageConsumer, times(1)).loopReadAndProcess();
+
+        //ToDo Ensure error consumer is not called
     }
 }


### PR DESCRIPTION
If the app is started in error processing mode, it should not consume the main and retry topics, and only consume the error topic.
This PR doesn't cover the error topic but allows the app on start up to differentiate between it being in normal or error processing mode
Lazily instantiate the kafka beans as the app subscribes to the kafka topics once the beans are instantiated
Without Lazy even when in error mode the service subscribes to the main and retry topics