### PR TITLE
BI-6742 Fix http status code appearing in logs incorrectly

### DIFF
--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImpl.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.chipsrestinterfacesconsumer.service.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpStatusCodeException;
 import uk.gov.companieshouse.chips.ChipsRestInterfacesSend;
@@ -44,7 +45,8 @@ public class MessageProcessorServiceImpl implements MessageProcessorService {
         try {
             chipsRestClient.sendToChips(message);
         } catch (HttpStatusCodeException hsce) {
-            logMap.put("HTTP Status Code", hsce.getStatusCode());
+            HttpStatus status = hsce.getStatusCode();
+            logMap.put("HTTP Status Code", status == null ? "null" : status.toString());
             handleFailedMessage(message, hsce, logMap);
         } catch (Exception e) {
             handleFailedMessage(message, e, logMap);

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImpl.java
@@ -2,7 +2,6 @@ package uk.gov.companieshouse.chipsrestinterfacesconsumer.service.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpStatusCodeException;
 import uk.gov.companieshouse.chips.ChipsRestInterfacesSend;

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImpl.java
@@ -46,7 +46,7 @@ public class MessageProcessorServiceImpl implements MessageProcessorService {
             chipsRestClient.sendToChips(message);
         } catch (HttpStatusCodeException hsce) {
             HttpStatus status = hsce.getStatusCode();
-            logMap.put("HTTP Status Code", status == null ? "null" : status.toString());
+            logMap.put("HTTP Status Code", status != null ? status.toString() : "null");
             handleFailedMessage(message, hsce, logMap);
         } catch (Exception e) {
             handleFailedMessage(message, e, logMap);

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImpl.java
@@ -45,8 +45,7 @@ public class MessageProcessorServiceImpl implements MessageProcessorService {
         try {
             chipsRestClient.sendToChips(message);
         } catch (HttpStatusCodeException hsce) {
-            HttpStatus status = hsce.getStatusCode();
-            logMap.put("HTTP Status Code", status != null ? status.toString() : "null");
+            logMap.put("HTTP Status Code", hsce.getStatusCode().toString());
             handleFailedMessage(message, hsce, logMap);
         } catch (Exception e) {
             handleFailedMessage(message, e, logMap);

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImplTest.java
@@ -12,6 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestClientException;
 import uk.gov.companieshouse.chips.ChipsRestInterfacesSend;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.client.ChipsRestClient;
@@ -40,6 +41,9 @@ class MessageProcessorServiceImplTest {
     private static final String ERROR_TOPIC = "chips-rest-interfaces-send-error";
 
     private ChipsRestInterfacesSend chipsRestInterfacesSend;
+
+    @Mock
+    private HttpStatusCodeException httpStatusCodeException;
 
     @Mock
     private ChipsRestClient chipsRestClient;
@@ -168,11 +172,24 @@ class MessageProcessorServiceImplTest {
         verify(messageProducer, times(1)).writeToTopic(chipsRestInterfacesSend, ERROR_TOPIC);
     }
 
+    @Test
+    void testNullHttpStatusCode() throws ServiceException {
+        doThrow(httpStatusCodeException).when(chipsRestClient).sendToChips(chipsRestInterfacesSend);
+
+        messageProcessorService.processMessage(chipsRestInterfacesSend);
+
+        verify(chipsRestClient, times(1)).sendToChips(eq(chipsRestInterfacesSend));
+        verify(logger, times(1)).error(eq(String.format(CHIPS_ERROR_MESSAGE, MESSAGE_ID)), eq(httpStatusCodeException), mapArgumentCaptor.capture());
+        Map<String, Object> logMap = mapArgumentCaptor.getValue();
+        verifyLogData(logMap);
+        assertEquals("null", logMap.get(LOG_KEY_HTTP_CODE));
+    }
+
     private void verifyLogData(Map<String, Object> logMap) {
         assertEquals(DUMMY_DATA, logMap.get(LOG_KEY_MESSAGE));
     }
 
     private void verifyLogHttpCode(Map<String, Object> logMap) {
-        assertEquals(HttpStatus.BAD_GATEWAY, logMap.get(LOG_KEY_HTTP_CODE));
+        assertEquals(HttpStatus.BAD_GATEWAY.toString(), logMap.get(LOG_KEY_HTTP_CODE));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImplTest.java
@@ -12,7 +12,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
-import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestClientException;
 import uk.gov.companieshouse.chips.ChipsRestInterfacesSend;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.client.ChipsRestClient;
@@ -41,9 +40,6 @@ class MessageProcessorServiceImplTest {
     private static final String ERROR_TOPIC = "chips-rest-interfaces-send-error";
 
     private ChipsRestInterfacesSend chipsRestInterfacesSend;
-
-    @Mock
-    private HttpStatusCodeException httpStatusCodeException;
 
     @Mock
     private ChipsRestClient chipsRestClient;
@@ -170,19 +166,6 @@ class MessageProcessorServiceImplTest {
 
         verify(messageProducer, times(0)).writeToTopic(any(), eq(RETRY_TOPIC));
         verify(messageProducer, times(1)).writeToTopic(chipsRestInterfacesSend, ERROR_TOPIC);
-    }
-
-    @Test
-    void testNullHttpStatusCode() throws ServiceException {
-        doThrow(httpStatusCodeException).when(chipsRestClient).sendToChips(chipsRestInterfacesSend);
-
-        messageProcessorService.processMessage(chipsRestInterfacesSend);
-
-        verify(chipsRestClient, times(1)).sendToChips(eq(chipsRestInterfacesSend));
-        verify(logger, times(1)).error(eq(String.format(CHIPS_ERROR_MESSAGE, MESSAGE_ID)), eq(httpStatusCodeException), mapArgumentCaptor.capture());
-        Map<String, Object> logMap = mapArgumentCaptor.getValue();
-        verifyLogData(logMap);
-        assertEquals("null", logMap.get(LOG_KEY_HTTP_CODE));
     }
 
     private void verifyLogData(Map<String, Object> logMap) {


### PR DESCRIPTION
Http Status code was truncated when viewed in non human log mode, due to not converting the HttpStatus code object to a string prior to logging.
Originally had null check for status code but sonar highlighted it and looks like it can never be null.