### PR TITLE
BI-6738 Setting retry consumer poll to double the retry delay and add…

### DIFF
--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/KafkaConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/KafkaConfiguration.java
@@ -38,6 +38,9 @@ class KafkaConfiguration {
     @Value("${kafka.producer.retries}")
     private int retries;
 
+    @Value("${RETRY_THROTTLE_RATE_SECONDS}")
+    private long retryThrottleSeconds;
+
     @Bean
     DeserializerFactory getDeserializerFactory() {
         return new DeserializerFactory();
@@ -73,7 +76,7 @@ class KafkaConfiguration {
         ConsumerConfig config = new ConsumerConfig();
         config.setBrokerAddresses(new String[]{brokerAddress});
         config.setTopics(Collections.singletonList(retryTopicName));
-        config.setPollTimeout(pollTimeout);
+        config.setPollTimeout(retryThrottleSeconds * 2 * 1000);
         config.setGroupName(retryConsumerGroupName);
         return config;
     }

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/KafkaConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/KafkaConfiguration.java
@@ -76,7 +76,7 @@ class KafkaConfiguration {
         ConsumerConfig config = new ConsumerConfig();
         config.setBrokerAddresses(new String[]{brokerAddress});
         config.setTopics(Collections.singletonList(retryTopicName));
-        config.setPollTimeout(retryThrottleSeconds * 2 * 1000);
+        config.setPollTimeout((retryThrottleSeconds * 1000) + pollTimeout);
         config.setGroupName(retryConsumerGroupName);
         return config;
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,4 @@ kafka.consumer.topic=${KAFKA_CONSUMER_TOPIC}
 kafka.retry.topic=${KAFKA_CONSUMER_TOPIC}-retry
 kafka.error.topic=${KAFKA_CONSUMER_TOPIC}-error
 kafka.producer.retries=${KAFKA_PRODUCER_RETRIES}
+kafka.consumer.pollTimeout=${KAFKA_CONSUMER_POLL_TIMEOUT_MS}

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/KafkaConfigurationTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/KafkaConfigurationTest.java
@@ -65,7 +65,7 @@ class KafkaConfigurationTest {
         assertEquals(BROKER_ADDRESS_VALUE, consumerConfig.getBrokerAddresses()[0]);
         assertEquals(1, consumerConfig.getTopics().size());
         assertEquals(RETRY_TOPIC_NAME_VALUE, consumerConfig.getTopics().get(0));
-        assertEquals(20000, consumerConfig.getPollTimeout());
+        assertEquals((THROTTLE_DELAY * 1000) + POLL_TIMEOUT_VALUE, consumerConfig.getPollTimeout());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/KafkaConfigurationTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/KafkaConfigurationTest.java
@@ -25,6 +25,7 @@ class KafkaConfigurationTest {
     private static final String RETRY_TOPIC_NAME_VALUE = "retry-topic";
     private static final int POLL_TIMEOUT_VALUE = 100;
     private static final int RETRIES = 10;
+    private static final int THROTTLE_DELAY = 10;
 
     private KafkaConfiguration kafkaConfiguration;
 
@@ -38,6 +39,7 @@ class KafkaConfigurationTest {
         ReflectionTestUtils.setField(kafkaConfiguration, "retryTopicName", RETRY_TOPIC_NAME_VALUE);
         ReflectionTestUtils.setField(kafkaConfiguration, "pollTimeout", POLL_TIMEOUT_VALUE);
         ReflectionTestUtils.setField(kafkaConfiguration, "retries", RETRIES);
+        ReflectionTestUtils.setField(kafkaConfiguration, "retryThrottleSeconds", THROTTLE_DELAY);
     }
 
     @Test
@@ -63,7 +65,7 @@ class KafkaConfigurationTest {
         assertEquals(BROKER_ADDRESS_VALUE, consumerConfig.getBrokerAddresses()[0]);
         assertEquals(1, consumerConfig.getTopics().size());
         assertEquals(RETRY_TOPIC_NAME_VALUE, consumerConfig.getTopics().get(0));
-        assertEquals(100, consumerConfig.getPollTimeout());
+        assertEquals(20000, consumerConfig.getPollTimeout());
     }
 
     @Test


### PR DESCRIPTION
…ing missing config for consumer timeout.

The kafka.consumer.pollTimeout config was missing so it wasn't reading from config and defaulting to 100. That wasn't the issue but was a different issue. To fix the poll timeouts for retries, i've set the timeout value to be double the retry delay.