### PR TITLE
Ensuring context is added to all logs

### DIFF
--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/client/ChipsRestClient.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/client/ChipsRestClient.java
@@ -14,6 +14,8 @@ import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogge
 
 import javax.annotation.PostConstruct;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 @Service
 public class ChipsRestClient {
@@ -36,7 +38,10 @@ public class ChipsRestClient {
         chipsRestUrl = new UriTemplate(String.format("%s{%s}", chipsRestHost, CHIPS_REST_ENDPOINT_URI_VAR));
     }
 
-    public void sendToChips(ChipsRestInterfacesSend message) {
+    public void sendToChips(ChipsRestInterfacesSend message, String consumerId) {
+        Map<String, Object> logMap = new HashMap<>();
+        logMap.put("Group Id", consumerId);
+
         var messageData = message.getData();
         var restEndpoint = message.getChipsRestEndpoint();
 
@@ -48,7 +53,7 @@ public class ChipsRestClient {
 
         var expandedUrl = chipsRestUrl.expand(uriVariables);
         var messageId = message.getMessageId();
-        logger.infoContext(messageId , String.format("Posting this message to %s", expandedUrl));
+        logger.infoContext(messageId , String.format("Posting this message to %s", expandedUrl), logMap);
         HttpEntity<String> requestEntity = new HttpEntity<>(messageData, requestHeaders);
         var response = restTemplate.exchange(
                 expandedUrl,
@@ -58,6 +63,6 @@ public class ChipsRestClient {
         );
 
         logger.infoContext(messageId, String.format(
-                "Message successfully sent, Chips Rest Response Status: %s", response.getStatusCode()));
+                "Message successfully sent, Chips Rest Response Status: %s", response.getStatusCode()), logMap);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/ErrorConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/ErrorConsumer.java
@@ -1,12 +1,14 @@
 package uk.gov.companieshouse.chipsrestinterfacesconsumer.consumer;
 
-import org.springframework.messaging.MessageHeaders;
-import org.springframework.messaging.handler.annotation.Headers;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.Payload;
 import uk.gov.companieshouse.chips.ChipsRestInterfacesSend;
 
 public interface ErrorConsumer {
     void readAndProcessErrorTopic(@Payload ChipsRestInterfacesSend data,
-                                 @Headers MessageHeaders headers);
+                                  @Header(KafkaHeaders.OFFSET) Long offset,
+                                  @Header(KafkaHeaders.RECEIVED_PARTITION_ID) Integer partition,
+                                  @Header(KafkaHeaders.GROUP_ID) String groupId);
 
 }

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/MainConsumerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/MainConsumerImpl.java
@@ -11,7 +11,6 @@ import uk.gov.companieshouse.chips.ChipsRestInterfacesSend;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.consumer.MainConsumer;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.service.MessageProcessorService;
-import uk.gov.companieshouse.service.ServiceException;
 
 import javax.annotation.PostConstruct;
 import java.util.HashMap;
@@ -60,7 +59,7 @@ public class MainConsumerImpl implements MainConsumer {
      *
      * @param messages A list of deserialized messages from Kafka
      * @param offsets A list of the offsets for the messages in {@code data}
-     * @param partitions A list of the partitiona for the messages in {@code data}
+     * @param partitions A list of the partitions for the messages in {@code data}
      * @param groupId The group id of the consumer
      */
     @Override
@@ -94,14 +93,9 @@ public class MainConsumerImpl implements MainConsumer {
         logMap.put("Partition", partition);
         logMap.put("Offset", offset);
 
-        try {
-            logger.infoContext(messageId, String.format("%s: Consumed Message from Partition: %s, Offset: %s", consumerId, partition, offset), logMap);
-            logger.infoContext(messageId, String.format("received data='%s'", data), logMap);
-            messageProcessorService.processMessage(consumerId, data);
-        } catch (ServiceException se) {
-            logger.errorContext(messageId, "Failed to process message", se);
-        } finally {
-            logger.infoContext(messageId, String.format("%s: Finished Processing Message from Partition: %s, Offset: %s", consumerId, partition, offset), logMap);
-        }
+        logger.infoContext(messageId, String.format("%s: Consumed Message from Partition: %s, Offset: %s", consumerId, partition, offset), logMap);
+        logger.infoContext(messageId, String.format("received data='%s'", data), logMap);
+        logger.infoContext(messageId, String.format("%s: Finished Processing Message from Partition: %s, Offset: %s", consumerId, partition, offset), logMap);
+        messageProcessorService.processMessage(consumerId, data);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/producer/impl/MessageProducerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/producer/impl/MessageProducerImpl.java
@@ -22,19 +22,20 @@ public class MessageProducerImpl implements MessageProducer {
 
     @Override
     public void writeToTopic(ChipsRestInterfacesSend chipsMessage, String topicName) {
+        var messageId = chipsMessage.getMessageId();
         var future = kafkaTemplate.send(topicName, chipsMessage);
 
         future.addCallback(new ListenableFutureCallback<>() {
 
             @Override
             public void onSuccess(SendResult<String, ChipsRestInterfacesSend> result) {
-                logger.info("Sent message=[" + chipsMessage +
+                logger.infoContext(messageId, "Sent message=[" + chipsMessage +
                         "] with offset=[" + result.getRecordMetadata().offset() + "]");
             }
 
             @Override
             public void onFailure(Throwable ex) {
-                logger.error("Unable to send message=["
+                logger.errorContext(messageId, "Unable to send message=["
                         + chipsMessage + "] due to : " + ex.getMessage(), new Exception(ex));
             }
         });

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/MessageProcessorService.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/MessageProcessorService.java
@@ -1,8 +1,7 @@
 package uk.gov.companieshouse.chipsrestinterfacesconsumer.service;
 
 import uk.gov.companieshouse.chips.ChipsRestInterfacesSend;
-import uk.gov.companieshouse.service.ServiceException;
 
 public interface MessageProcessorService {
-    void processMessage(String consumerId, ChipsRestInterfacesSend message) throws ServiceException;
+    void processMessage(String consumerId, ChipsRestInterfacesSend message);
 }

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImpl.java
@@ -9,7 +9,6 @@ import uk.gov.companieshouse.chipsrestinterfacesconsumer.client.ChipsRestClient;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.producer.MessageProducer;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.service.MessageProcessorService;
-import uk.gov.companieshouse.service.ServiceException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -41,13 +40,12 @@ public class MessageProcessorServiceImpl implements MessageProcessorService {
     private MessageProducer messageProducer;
 
     @Override
-    public void processMessage(String consumerId, ChipsRestInterfacesSend message) throws ServiceException{
+    public void processMessage(String consumerId, ChipsRestInterfacesSend message) {
         Map<String, Object> logMap = new HashMap<>();
         logMap.put("Message", message.getData());
-        logMap.put("Thread Name", Thread.currentThread().getName());
         logMap.put("Message Consumer ID", consumerId);
         try {
-            chipsRestClient.sendToChips(message);
+            chipsRestClient.sendToChips(message, consumerId);
         } catch (HttpStatusCodeException hsce) {
             logMap.put("HTTP Status Code", hsce.getStatusCode().toString());
             handleFailedMessage(message, hsce, logMap);

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/client/ChipsRestClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/client/ChipsRestClientTest.java
@@ -22,6 +22,7 @@ import java.net.URI;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -59,7 +60,7 @@ class ChipsRestClientTest {
         when(restTemplate.exchange(any(URI.class), eq(HttpMethod.POST), any(), eq(String.class))).thenReturn(responseEntity);
 
         chipsRestClient.init();
-        chipsRestClient.sendToChips(chipsRestInterfacesSend);
+        chipsRestClient.sendToChips(chipsRestInterfacesSend, "CONSUMER-ID");
 
         verify(restTemplate, times(1)).exchange(
                 eq(FULL_EXPANDED_CHIPS_REST_URL), eq(HttpMethod.POST), messageDataArgCaptor.capture(),
@@ -72,8 +73,8 @@ class ChipsRestClientTest {
         assertEquals(MediaType.APPLICATION_JSON, messageData.getHeaders().getContentType());
 
         verify(logger, times(1))
-                .infoContext(messageId, String.format("Posting this message to %s", FULL_EXPANDED_CHIPS_REST_URL));
+                .infoContext(eq(messageId), eq(String.format("Posting this message to %s", FULL_EXPANDED_CHIPS_REST_URL)), anyMap());
         verify(logger, times(1))
-                .infoContext(messageId, String.format("Message successfully sent, Chips Rest Response Status: %s", HttpStatus.ACCEPTED));
+                .infoContext(eq(messageId), eq(String.format("Message successfully sent, Chips Rest Response Status: %s", HttpStatus.ACCEPTED)), anyMap());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImplTest.java
@@ -6,13 +6,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.messaging.MessageHeaders;
 import uk.gov.companieshouse.chips.ChipsRestInterfacesSend;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.service.MessageProcessorService;
 import uk.gov.companieshouse.service.ServiceException;
-
-import java.util.Collections;
 
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -33,18 +30,16 @@ class ErrorConsumerImplTest {
     private ErrorConsumerImpl errorConsumer;
 
     private ChipsRestInterfacesSend data;
-    private MessageHeaders headers;
 
     @BeforeEach
     void init() {
         data = new ChipsRestInterfacesSend();
         data.setData(DATA);
-        headers = new MessageHeaders(Collections.singletonMap("Key", "Value"));
     }
 
     @Test
     void readAndProcessErrorTopic() throws ServiceException {
-        errorConsumer.readAndProcessErrorTopic(data, headers);
+        errorConsumer.readAndProcessErrorTopic(data, 0L, 0, ERROR_CONSUMER_ID);
 
         verify(messageProcessorService, times(1)).processMessage(ERROR_CONSUMER_ID, data);
     }

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/MainConsumerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/MainConsumerImplTest.java
@@ -6,14 +6,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.messaging.MessageHeaders;
 import uk.gov.companieshouse.chips.ChipsRestInterfacesSend;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.service.MessageProcessorService;
 import uk.gov.companieshouse.service.ServiceException;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
Many logs were missing the message id added as context.
This pr adds the id and the consumer id as well.