### PR TITLE
Feature/bi 6826 multiple companies bug

### DIFF
--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/KafkaProducerConfig.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/KafkaProducerConfig.java
@@ -24,6 +24,12 @@ public class KafkaProducerConfig {
     @Value("${kafka.producer.retries}")
     private int retries;
 
+    @Value("${kafka.producer.batch.size.bytes}")
+    private int batchSizeBytes;
+
+    @Value("${kafka.producer.linger.ms}")
+    private int lingerMs;
+
     @Bean
     public ProducerFactory<String, ChipsRestInterfacesSend> producerFactory() {
         Map<String, Object> configProps = new HashMap<>();
@@ -36,9 +42,12 @@ public class KafkaProducerConfig {
         configProps.put(
                 ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
                 AvroSerializer.class);
-           configProps.put(
+        configProps.put(
+                ProducerConfig.BATCH_SIZE_CONFIG,
+                batchSizeBytes);
+        configProps.put(
                 ProducerConfig.LINGER_MS_CONFIG,
-                2000);
+                lingerMs);
         return new DefaultKafkaProducerFactory<>(configProps);
     }
 

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/KafkaProducerConfig.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/KafkaProducerConfig.java
@@ -36,6 +36,9 @@ public class KafkaProducerConfig {
         configProps.put(
                 ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
                 AvroSerializer.class);
+           configProps.put(
+                ProducerConfig.LINGER_MS_CONFIG,
+                2000);
         return new DefaultKafkaProducerFactory<>(configProps);
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,4 +8,6 @@ kafka.consumer.max.poll.interval.ms=${KAFKA_MAX_POLL_INTERVAL_MS}
 kafka.retry.topic=${KAFKA_CONSUMER_TOPIC}-retry
 kafka.error.topic=${KAFKA_CONSUMER_TOPIC}-error
 kafka.producer.retries=${KAFKA_PRODUCER_RETRIES}
+kafka.producer.batch.size.bytes=${KAFKA_PRODUCER_BATCH_SIZE_BYTES}
+kafka.producer.linger.ms=${KAFKA_PRODUCER_LINGER_MS}
 feature.errorMode=${RUN_APP_IN_ERROR_MODE}

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/KafkaProducerConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/KafkaProducerConfigTest.java
@@ -1,0 +1,34 @@
+package uk.gov.companieshouse.chipsrestinterfacesconsumer.configuration;
+
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class KafkaProducerConfigTest {
+
+    private static final String BROKER_ADDRESS = "BROKER";
+    private static final int KAFKA_PRODUCER_BATCH_SIZE_BYTES = 131072;
+    private static final int KAFKA_PRODUCER_LINGER_MS = 500;
+
+    private KafkaProducerConfig kafkaProducerConfig;
+
+    @BeforeEach
+    void init() {
+        kafkaProducerConfig = new KafkaProducerConfig();
+        ReflectionTestUtils.setField(kafkaProducerConfig, "brokerAddress", BROKER_ADDRESS);
+        ReflectionTestUtils.setField(kafkaProducerConfig, "batchSizeBytes", KAFKA_PRODUCER_BATCH_SIZE_BYTES);
+        ReflectionTestUtils.setField(kafkaProducerConfig, "lingerMs", KAFKA_PRODUCER_LINGER_MS);
+    }
+
+    @Test
+    void testKafkaConfigValues() {
+        var factory = kafkaProducerConfig.producerFactory();
+        assertEquals(BROKER_ADDRESS, factory.getConfigurationProperties().get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG));
+        assertEquals(KAFKA_PRODUCER_BATCH_SIZE_BYTES, factory.getConfigurationProperties().get(ProducerConfig.BATCH_SIZE_CONFIG));
+        assertEquals(KAFKA_PRODUCER_LINGER_MS, factory.getConfigurationProperties().get(ProducerConfig.LINGER_MS_CONFIG));
+    }
+}


### PR DESCRIPTION
Added config variable references to specify a linger period and batch size for the retry producer in order to prevent the  message batch being split over several iterations; the batch of messages should be processed alll together. The linger period give the producer time to collect all the messages into one single batch transaction. There is no 100% guaratee that this will not happen with larger batches.