### PR TITLE
Feature/bi 6774 slack notification

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,11 @@
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.slack.api</groupId>
+            <artifactId>slack-api-client</artifactId>
+            <version>1.5.3</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/common/ApplicationLogger.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/common/ApplicationLogger.java
@@ -71,6 +71,10 @@ public class ApplicationLogger {
         logger.errorContext(context, message, e, cloneMapData(dataMap));
     }
 
+    public void error(String message) {
+        logger.error(message);
+    }
+
     public void error(String message, Exception e) {
         logger.error(message, e);
     }

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImpl.java
@@ -66,12 +66,12 @@ public class ErrorConsumerImpl implements ErrorConsumer {
         logger.infoContext(messageId, String.format("%s: Consumed Message from Partition: %s, Offset: %s", groupId, partition, offset), logMap);
         logger.infoContext(messageId, String.format("received data='%s'", data), logMap);
 
-        List<String> failedMessages = new ArrayList<>();
-        messageProcessorService.processMessage("error-consumer", data, failedMessages);
+        List<String> failedMessageIds = new ArrayList<>();
+        messageProcessorService.processMessage("error-consumer", data, failedMessageIds);
         logger.infoContext(messageId, String.format("%s: Finished Processing Message from Partition: %s, Offset: %s", groupId, partition, offset), logMap);
 
-        if (!failedMessages.isEmpty()) {
-            slackMessagingService.sendMessage(failedMessages);
+        if (!failedMessageIds.isEmpty()) {
+            slackMessagingService.sendMessage(failedMessageIds);
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImpl.java
@@ -14,9 +14,7 @@ import uk.gov.companieshouse.chipsrestinterfacesconsumer.service.MessageProcesso
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.slack.SlackMessagingService;
 
 import javax.annotation.PostConstruct;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 @Service
@@ -25,15 +23,12 @@ public class ErrorConsumerImpl implements ErrorConsumer {
 
     private final ApplicationLogger logger;
     private final MessageProcessorService messageProcessorService;
-    private final SlackMessagingService slackMessagingService;
 
     @Autowired
     public ErrorConsumerImpl(ApplicationLogger logger,
-                             MessageProcessorService messageProcessorService,
-                             SlackMessagingService slackMessagingService) {
+                             MessageProcessorService messageProcessorService) {
         this.logger = logger;
         this.messageProcessorService = messageProcessorService;
-        this.slackMessagingService = slackMessagingService;
     }
 
     @PostConstruct

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImpl.java
@@ -11,7 +11,6 @@ import uk.gov.companieshouse.chips.ChipsRestInterfacesSend;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.consumer.ErrorConsumer;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.service.MessageProcessorService;
-import uk.gov.companieshouse.chipsrestinterfacesconsumer.slack.SlackMessagingService;
 
 import javax.annotation.PostConstruct;
 import java.util.HashMap;

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImpl.java
@@ -71,7 +71,7 @@ public class ErrorConsumerImpl implements ErrorConsumer {
         messageProcessorService.processMessage("error-consumer", data, failedMessageOpt);
         logger.infoContext(messageId, String.format("%s: Finished Processing Message from Partition: %s, Offset: %s", groupId, partition, offset), logMap);
 
-        if (failedMessageOpt.isPresent() && !failedMessageOpt.get().isEmpty()) {
+        if (!failedMessageOpt.get().isEmpty()) {
             slackMessagingService.sendMessage(failedMessageOpt.get());
         }
     }

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImpl.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 @Service
 @ConditionalOnProperty(prefix = "feature", name = "errorMode", havingValue = "true")
@@ -67,12 +66,12 @@ public class ErrorConsumerImpl implements ErrorConsumer {
         logger.infoContext(messageId, String.format("%s: Consumed Message from Partition: %s, Offset: %s", groupId, partition, offset), logMap);
         logger.infoContext(messageId, String.format("received data='%s'", data), logMap);
 
-        Optional<List<String>> failedMessageOpt = Optional.of(new ArrayList<>());
-        messageProcessorService.processMessage("error-consumer", data, failedMessageOpt);
+        List<String> failedMessages = new ArrayList<>();
+        messageProcessorService.processMessage("error-consumer", data, failedMessages);
         logger.infoContext(messageId, String.format("%s: Finished Processing Message from Partition: %s, Offset: %s", groupId, partition, offset), logMap);
 
-        if (!failedMessageOpt.get().isEmpty()) {
-            slackMessagingService.sendMessage(failedMessageOpt.get());
+        if (!failedMessages.isEmpty()) {
+            slackMessagingService.sendMessage(failedMessages);
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImpl.java
@@ -66,12 +66,8 @@ public class ErrorConsumerImpl implements ErrorConsumer {
         logger.infoContext(messageId, String.format("%s: Consumed Message from Partition: %s, Offset: %s", groupId, partition, offset), logMap);
         logger.infoContext(messageId, String.format("received data='%s'", data), logMap);
 
-        List<String> failedMessageIds = new ArrayList<>();
-        messageProcessorService.processMessage("error-consumer", data, failedMessageIds);
-        logger.infoContext(messageId, String.format("%s: Finished Processing Message from Partition: %s, Offset: %s", groupId, partition, offset), logMap);
 
-        if (!failedMessageIds.isEmpty()) {
-            slackMessagingService.sendMessage(failedMessageIds);
-        }
+        messageProcessorService.processMessage("error-consumer", data, null);
+        logger.infoContext(messageId, String.format("%s: Finished Processing Message from Partition: %s, Offset: %s", groupId, partition, offset), logMap);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/MainConsumerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/MainConsumerImpl.java
@@ -79,7 +79,7 @@ public class MainConsumerImpl implements MainConsumer {
 
         logger.debug(String.format("%s, received %s messages", groupId, messages.size()));
 
-       List<String> failedMessageIds = new ArrayList<>();
+        List<String> failedMessageIds = new ArrayList<>();
 
         for (int i = 0; i < messages.size(); i++) {
             processMessage(groupId, messages.get(i), offsets.get(i), partitions.get(i), failedMessageIds);

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/MainConsumerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/MainConsumerImpl.java
@@ -11,6 +11,7 @@ import uk.gov.companieshouse.chips.ChipsRestInterfacesSend;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.consumer.MainConsumer;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.service.MessageProcessorService;
+import uk.gov.companieshouse.chipsrestinterfacesconsumer.slack.SlackMessagingService;
 
 import javax.annotation.PostConstruct;
 import java.util.HashMap;
@@ -23,6 +24,9 @@ public class MainConsumerImpl implements MainConsumer {
 
     private final ApplicationLogger logger;
     private final MessageProcessorService messageProcessorService;
+
+    @Autowired
+    private SlackMessagingService slackMessagingService;
 
     @Autowired
     public MainConsumerImpl(ApplicationLogger logger, MessageProcessorService messageProcessorService) {
@@ -75,7 +79,13 @@ public class MainConsumerImpl implements MainConsumer {
             processMessage(groupId, messages.get(i), offsets.get(i), partitions.get(i));
         }
 
+        List<String> failedMessageIds = messageProcessorService.getFailedMessages();
+        if (!failedMessageIds.isEmpty()) {
+            slackMessagingService.sendMessage(failedMessageIds);
+        }
     }
+
+
 
     /**
      * Delegates the processing of the message to the {@code messageProcessorService}

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/MainConsumerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/MainConsumerImpl.java
@@ -25,13 +25,15 @@ public class MainConsumerImpl implements MainConsumer {
     private final ApplicationLogger logger;
     private final MessageProcessorService messageProcessorService;
 
-    @Autowired
     private SlackMessagingService slackMessagingService;
 
     @Autowired
-    public MainConsumerImpl(ApplicationLogger logger, MessageProcessorService messageProcessorService) {
+    public MainConsumerImpl(ApplicationLogger logger,
+                            MessageProcessorService messageProcessorService,
+                            SlackMessagingService slackMessagingService) {
         this.logger = logger;
         this.messageProcessorService = messageProcessorService;
+        this.slackMessagingService = slackMessagingService;
     }
 
     @PostConstruct

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/MainConsumerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/MainConsumerImpl.java
@@ -87,8 +87,6 @@ public class MainConsumerImpl implements MainConsumer {
         }
     }
 
-
-
     /**
      * Delegates the processing of the message to the {@code messageProcessorService}
      * and handles any unexpected errors

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/MainConsumerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/MainConsumerImpl.java
@@ -27,7 +27,7 @@ public class MainConsumerImpl implements MainConsumer {
     private final ApplicationLogger logger;
     private final MessageProcessorService messageProcessorService;
 
-    private SlackMessagingService slackMessagingService;
+    private final SlackMessagingService slackMessagingService;
 
     @Autowired
     public MainConsumerImpl(ApplicationLogger logger,
@@ -86,7 +86,7 @@ public class MainConsumerImpl implements MainConsumer {
             processMessage(groupId, messages.get(i), offsets.get(i), partitions.get(i), failedMessageOpt);
         }
 
-        if (failedMessageOpt.isPresent() && !failedMessageOpt.get().isEmpty()) {
+        if (!failedMessageOpt.get().isEmpty()) {
             slackMessagingService.sendMessage(failedMessageOpt.get());
         }
     }

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/MainConsumerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/MainConsumerImpl.java
@@ -79,14 +79,14 @@ public class MainConsumerImpl implements MainConsumer {
 
         logger.debug(String.format("%s, received %s messages", groupId, messages.size()));
 
-       List<String> failedMessages = new ArrayList<>();
+       List<String> failedMessageIds = new ArrayList<>();
 
         for (int i = 0; i < messages.size(); i++) {
-            processMessage(groupId, messages.get(i), offsets.get(i), partitions.get(i), failedMessages);
+            processMessage(groupId, messages.get(i), offsets.get(i), partitions.get(i), failedMessageIds);
         }
 
-        if (!failedMessages.isEmpty()) {
-            slackMessagingService.sendMessage(failedMessages);
+        if (!failedMessageIds.isEmpty()) {
+            slackMessagingService.sendMessage(failedMessageIds);
         }
     }
 
@@ -103,7 +103,7 @@ public class MainConsumerImpl implements MainConsumer {
                                 ChipsRestInterfacesSend data,
                                 Long offset,
                                 Integer partition,
-                                List<String> failedMessages) {
+                                List<String> failedMessageIds) {
 
         var messageId = data.getMessageId();
         Map<String, Object> logMap = new HashMap<>();
@@ -114,6 +114,6 @@ public class MainConsumerImpl implements MainConsumer {
         logger.infoContext(messageId, String.format("%s: Consumed Message from Partition: %s, Offset: %s", consumerId, partition, offset), logMap);
         logger.infoContext(messageId, String.format("received data='%s'", data), logMap);
         logger.infoContext(messageId, String.format("%s: Finished Processing Message from Partition: %s, Offset: %s", consumerId, partition, offset), logMap);
-        messageProcessorService.processMessage(consumerId, data, failedMessages);
+        messageProcessorService.processMessage(consumerId, data, failedMessageIds);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/MessageProcessorService.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/MessageProcessorService.java
@@ -5,5 +5,5 @@ import uk.gov.companieshouse.chips.ChipsRestInterfacesSend;
 import java.util.List;
 
 public interface MessageProcessorService {
-    void processMessage(String consumerId, ChipsRestInterfacesSend message, List<String> failedMessages);
+    void processMessage(String consumerId, ChipsRestInterfacesSend message, List<String> failedMessageIds);
 }

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/MessageProcessorService.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/MessageProcessorService.java
@@ -3,8 +3,8 @@ package uk.gov.companieshouse.chipsrestinterfacesconsumer.service;
 import uk.gov.companieshouse.chips.ChipsRestInterfacesSend;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MessageProcessorService {
-    void processMessage(String consumerId, ChipsRestInterfacesSend message);
-    List<String> getFailedMessages();
+    void processMessage(String consumerId, ChipsRestInterfacesSend message, Optional<List<String>> failedMessageOpt);
 }

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/MessageProcessorService.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/MessageProcessorService.java
@@ -2,6 +2,9 @@ package uk.gov.companieshouse.chipsrestinterfacesconsumer.service;
 
 import uk.gov.companieshouse.chips.ChipsRestInterfacesSend;
 
+import java.util.List;
+
 public interface MessageProcessorService {
     void processMessage(String consumerId, ChipsRestInterfacesSend message);
+    List<String> getFailedMessages();
 }

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/MessageProcessorService.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/MessageProcessorService.java
@@ -3,8 +3,7 @@ package uk.gov.companieshouse.chipsrestinterfacesconsumer.service;
 import uk.gov.companieshouse.chips.ChipsRestInterfacesSend;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface MessageProcessorService {
-    void processMessage(String consumerId, ChipsRestInterfacesSend message, Optional<List<String>> failedMessageOpt);
+    void processMessage(String consumerId, ChipsRestInterfacesSend message, List<String> failedMessages);
 }

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImpl.java
@@ -10,10 +10,10 @@ import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogge
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.producer.MessageProducer;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.service.MessageProcessorService;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Vector;
 
 @Service
 public class MessageProcessorServiceImpl implements MessageProcessorService {
@@ -41,7 +41,7 @@ public class MessageProcessorServiceImpl implements MessageProcessorService {
     @Autowired
     private MessageProducer messageProducer;
 
-    private List<String> failedMessageIds = new Vector<String>();
+    private List<String> failedMessageIds = new ArrayList<String>();
 
     @Override
     public void processMessage(String consumerId, ChipsRestInterfacesSend message) {

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImpl.java
@@ -41,7 +41,7 @@ public class MessageProcessorServiceImpl implements MessageProcessorService {
     @Autowired
     private MessageProducer messageProducer;
 
-    private List<String> failedMessageIds = new ArrayList<String>();
+    private List<String> failedMessageIds = new ArrayList<>();
 
     @Override
     public void processMessage(String consumerId, ChipsRestInterfacesSend message) {

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImpl.java
@@ -9,7 +9,6 @@ import uk.gov.companieshouse.chipsrestinterfacesconsumer.client.ChipsRestClient;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.producer.MessageProducer;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.service.MessageProcessorService;
-import uk.gov.companieshouse.chipsrestinterfacesconsumer.slack.SlackMessagingService;
 
 import java.util.HashMap;
 import java.util.List;

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImpl.java
@@ -69,9 +69,6 @@ public class MessageProcessorServiceImpl implements MessageProcessorService {
         if (runAppInErrorMode) {
             message.setAttempt(1);
             messageProducer.writeToTopic(message, retryTopicName);
-            if(failedMessageIds != null) {
-                failedMessageIds.add(message.getMessageId());
-            }
             return;
         }
 

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImpl.java
@@ -43,7 +43,7 @@ public class MessageProcessorServiceImpl implements MessageProcessorService {
     @Override
     public void processMessage(String consumerId,
                                ChipsRestInterfacesSend message,
-                               List<String> failedMessage) {
+                               List<String> failedMessages) {
 
         Map<String, Object> logMap = new HashMap<>();
         logMap.put("Message", message.getData());
@@ -52,9 +52,9 @@ public class MessageProcessorServiceImpl implements MessageProcessorService {
             chipsRestClient.sendToChips(message, consumerId);
         } catch (HttpStatusCodeException hsce) {
             logMap.put("HTTP Status Code", hsce.getStatusCode().toString());
-            handleFailedMessage(message, hsce, logMap, failedMessage);
+            handleFailedMessage(message, hsce, logMap, failedMessages);
         } catch (Exception e) {
-            handleFailedMessage(message, e, logMap, failedMessage);
+            handleFailedMessage(message, e, logMap, failedMessages);
         }
     }
 

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImpl.java
@@ -10,7 +10,6 @@ import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogge
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.producer.MessageProducer;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.service.MessageProcessorService;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImpl.java
@@ -85,7 +85,7 @@ public class MessageProcessorServiceImpl implements MessageProcessorService {
         } else {
             logger.errorContext(messageId, String.format("Maximum retry attempts %s reached for this message", maxRetryAttempts), e, logMap);
             messageProducer.writeToTopic(message, errorTopicName);
-            if(failedMessageIds != null) {
+            if (failedMessageIds != null) {
                 failedMessageIds.add(message.getMessageId());
             }
         }

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImpl.java
@@ -75,7 +75,7 @@ public class MessageProcessorServiceImpl implements MessageProcessorService {
         if (attempts < maxRetryAttempts) {
             message.setAttempt(attempts + 1);
             messageProducer.writeToTopic(message, retryTopicName);
-            slackMessagingService.sendMessage(message.getMessageId(), logMap, errorMessage);
+            slackMessagingService.sendMessage(message.getMessageId(), errorMessage);
         } else {
             logger.errorContext(messageId, String.format("Maximum retry attempts %s reached for this message", maxRetryAttempts), e, logMap);
             messageProducer.writeToTopic(message, errorTopicName);

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/SlackMessagingService.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/SlackMessagingService.java
@@ -1,0 +1,10 @@
+package uk.gov.companieshouse.chipsrestinterfacesconsumer.slack;
+
+import java.util.Map;
+
+public interface SlackMessagingService {
+
+    void sendMessage(String kafkaMessageId,
+                     Map<String, Object> logMap,
+                     String errorMessage);
+}

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/SlackMessagingService.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/SlackMessagingService.java
@@ -4,6 +4,5 @@ import java.util.Map;
 
 public interface SlackMessagingService {
 
-    void sendMessage(String kafkaMessageId,
-                     String errorMessage);
+    void sendMessage(String kafkaMessageId);
 }

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/SlackMessagingService.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/SlackMessagingService.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.chipsrestinterfacesconsumer.slack;
 
 import java.util.List;
-import java.util.Map;
 
 public interface SlackMessagingService {
 

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/SlackMessagingService.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/SlackMessagingService.java
@@ -5,6 +5,5 @@ import java.util.Map;
 public interface SlackMessagingService {
 
     void sendMessage(String kafkaMessageId,
-                     Map<String, Object> logMap,
                      String errorMessage);
 }

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/SlackMessagingService.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/SlackMessagingService.java
@@ -1,8 +1,9 @@
 package uk.gov.companieshouse.chipsrestinterfacesconsumer.slack;
 
+import java.util.List;
 import java.util.Map;
 
 public interface SlackMessagingService {
 
-    void sendMessage(String kafkaMessageId);
+    void sendMessage(List<String> failedMessageIds);
 }

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImpl.java
@@ -67,7 +67,7 @@ public class SlackMessagingServiceImpl implements SlackMessagingService {
         String mode = (inErrorMode)? "error" : "normal";
 
         StringBuilder failedSb = new StringBuilder();
-        failedSb.append(String.format("In %s mode - Unable to send message with ids: \n", mode));
+        failedSb.append(String.format("In %s mode - Unable to send message with ids: %n", mode));
 
         int endIndex = (failedMessageIds.size() > LIMIT)? LIMIT : failedMessageIds.size();
         for(int index = 0; index < endIndex; index++){

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImpl.java
@@ -25,9 +25,6 @@ public class SlackMessagingServiceImpl implements SlackMessagingService {
     @Value("${SLACK_ACCESS_TOKEN}")
     private String slackAccessToken;
 
-    @Value("${RUN_APP_IN_ERROR_MODE}")
-    private boolean inErrorMode;
-
     @Autowired
     public SlackMessagingServiceImpl(ApplicationLogger logger) {
         this.logger = logger;
@@ -65,13 +62,14 @@ public class SlackMessagingServiceImpl implements SlackMessagingService {
     }
 
     private String buildMessage(List<String> failedMessageIds) {
-        String mode = (inErrorMode)? "error" : "normal";
 
         StringBuilder failedSb = new StringBuilder();
-        failedSb.append(String.format("In %s mode - Unable to send message with ids: %n", mode));
+        failedSb.append("Unable to send messages with ids: ");
+        failedSb.append("\n");
 
         for (String failedMessageId : failedMessageIds) {
-            failedSb.append(failedMessageId + "\n");
+            failedSb.append(failedMessageId);
+            failedSb.append("\n");
         }
 
         return failedSb.toString();

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImpl.java
@@ -32,7 +32,6 @@ public class SlackMessagingServiceImpl implements SlackMessagingService {
 
     @Override
     public void sendMessage(String kafkaMessageId,
-                            Map<String, Object> logMap,
                             String errorMessage) {
 
         try {
@@ -44,7 +43,11 @@ public class SlackMessagingServiceImpl implements SlackMessagingService {
                     .build();
 
             ChatPostMessageResponse response = methods.chatPostMessage(request);
-            logger.infoContext(kafkaMessageId, String.format("Message sent to: %s, response: %s", slackChannel, response));
+            if(response.isOk()) {
+                logger.infoContext(kafkaMessageId, String.format("Message sent to: %s", slackChannel));
+            } else {
+                logger.infoContext(kafkaMessageId, String.format("Message sent with response %s", response.getError()));
+            }
         } catch(IOException | SlackApiException e) {
             logger.errorContext(kafkaMessageId, "Slack error message not sent", e);
         }

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImpl.java
@@ -17,7 +17,6 @@ import java.util.List;
 @Service
 public class SlackMessagingServiceImpl implements SlackMessagingService {
 
-    public static final int LIMIT = 20;
     private final ApplicationLogger logger;
 
     @Value("${SLACK_CHANNEL}")
@@ -71,13 +70,10 @@ public class SlackMessagingServiceImpl implements SlackMessagingService {
         StringBuilder failedSb = new StringBuilder();
         failedSb.append(String.format("In %s mode - Unable to send message with ids: %n", mode));
 
-        int endIndex = (failedMessageIds.size() > LIMIT)? LIMIT : failedMessageIds.size();
-        for(int index = 0; index < endIndex; index++){
+        for(int index = 0; index < failedMessageIds.size(); index++){
             failedSb.append(failedMessageIds.get(index) + "\n");
         }
-        if (failedMessageIds.size() > LIMIT) {
-            failedSb.append(String.format("and %d more...", failedMessageIds.size() - LIMIT));
-        }
+
         return failedSb.toString();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImpl.java
@@ -46,7 +46,7 @@ public class SlackMessagingServiceImpl implements SlackMessagingService {
                     .build();
 
             ChatPostMessageResponse response = postSlackMessage(methods, request);
-            if(response.isOk()) {
+            if (response.isOk()) {
                 logger.info(String.format("Message sent to: %s", slackChannel));
             } else {
                 logger.error(String.format("Error message sent but received response: %s", response.getError()));
@@ -70,7 +70,7 @@ public class SlackMessagingServiceImpl implements SlackMessagingService {
         StringBuilder failedSb = new StringBuilder();
         failedSb.append(String.format("In %s mode - Unable to send message with ids: %n", mode));
 
-        for(String failedMessageId : failedMessageIds){
+        for (String failedMessageId : failedMessageIds) {
             failedSb.append(failedMessageId + "\n");
         }
 

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImpl.java
@@ -49,7 +49,7 @@ public class SlackMessagingServiceImpl implements SlackMessagingService {
             if(response.isOk()) {
                 logger.info(String.format("Message sent to: %s", slackChannel));
             } else {
-                logger.info(String.format("Error message sent but received response: %s", response.getError()));
+                logger.error(String.format("Error message sent but received response: %s", response.getError()));
             }
         } catch(IOException | SlackApiException e) {
             logger.errorContext("Slack error message not sent", e);
@@ -70,8 +70,8 @@ public class SlackMessagingServiceImpl implements SlackMessagingService {
         StringBuilder failedSb = new StringBuilder();
         failedSb.append(String.format("In %s mode - Unable to send message with ids: %n", mode));
 
-        for(int index = 0; index < failedMessageIds.size(); index++){
-            failedSb.append(failedMessageIds.get(index) + "\n");
+        for(String failedMessageId : failedMessageIds){
+            failedSb.append(failedMessageId + "\n");
         }
 
         return failedSb.toString();

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImpl.java
@@ -1,0 +1,52 @@
+package uk.gov.companieshouse.chipsrestinterfacesconsumer.slack.impl;
+
+import com.slack.api.Slack;
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+import com.slack.api.methods.response.chat.ChatPostMessageResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger;
+import uk.gov.companieshouse.chipsrestinterfacesconsumer.slack.SlackMessagingService;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Service
+public class SlackMessagingServiceImpl implements SlackMessagingService {
+
+    private final ApplicationLogger logger;
+
+    @Value("${SLACK_CHANNEL}")
+    private String slackChannel;
+
+    @Value("${SLACK_ACCESS_TOKEN}")
+    private String slackAccessToken;
+
+    @Autowired
+    public SlackMessagingServiceImpl(ApplicationLogger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public void sendMessage(String kafkaMessageId,
+                            Map<String, Object> logMap,
+                            String errorMessage) {
+
+        try {
+            Slack slack = Slack.getInstance();
+            MethodsClient methods = slack.methods(slackAccessToken);
+            ChatPostMessageRequest request = ChatPostMessageRequest.builder()
+                    .channel(slackChannel)
+                    .text(errorMessage)
+                    .build();
+
+            ChatPostMessageResponse response = methods.chatPostMessage(request);
+            logger.infoContext(kafkaMessageId, String.format("Message sent to: %s, response: %s", slackChannel, response));
+        } catch(IOException | SlackApiException e) {
+            logger.errorContext(kafkaMessageId, "Slack error message not sent", e);
+        }
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImplTest.java
@@ -10,7 +10,6 @@ import uk.gov.companieshouse.chips.ChipsRestInterfacesSend;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.service.MessageProcessorService;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.slack.SlackMessagingService;
-import uk.gov.companieshouse.service.ServiceException;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImplTest.java
@@ -9,12 +9,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.chips.ChipsRestInterfacesSend;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.service.MessageProcessorService;
-import uk.gov.companieshouse.chipsrestinterfacesconsumer.slack.SlackMessagingService;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -29,9 +27,6 @@ class ErrorConsumerImplTest {
 
     @Mock
     private ApplicationLogger logger;
-
-    @Mock
-    private SlackMessagingService slackMessagingService;
 
     @InjectMocks
     private ErrorConsumerImpl errorConsumer;
@@ -51,6 +46,5 @@ class ErrorConsumerImplTest {
         errorConsumer.readAndProcessErrorTopic(data, 0L, 0, ERROR_CONSUMER_ID);
 
         verify(messageProcessorService, times(1)).processMessage(ERROR_CONSUMER_ID, data, null);
-        verify(slackMessagingService,  never()).sendMessage(failedMessageIds);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImplTest.java
@@ -14,11 +14,11 @@ import uk.gov.companieshouse.service.ServiceException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ErrorConsumerImplTest {
@@ -49,22 +49,11 @@ class ErrorConsumerImplTest {
     @Test
     void readAndProcessErrorTopic() throws ServiceException {
         List<String> failedMessages = new ArrayList<>();
-        when(messageProcessorService.getFailedMessages()).thenReturn(failedMessages);
-
+        data.setAttempt(0);
         errorConsumer.readAndProcessErrorTopic(data, 0L, 0, ERROR_CONSUMER_ID);
 
-        verify(messageProcessorService, times(1)).processMessage(ERROR_CONSUMER_ID, data);
+        Optional<List<String>> failedMessageOpt = Optional.of(new ArrayList<>());
+        verify(messageProcessorService, times(1)).processMessage(ERROR_CONSUMER_ID, data, failedMessageOpt);
         verify(slackMessagingService,  never()).sendMessage(failedMessages);
-    }
-
-    @Test
-    void readAndProcessErrorTopicWithFailedMessages() throws ServiceException {
-        List<String> failedMessages = new ArrayList<>();
-        failedMessages.add("abc-123");
-        when(messageProcessorService.getFailedMessages()).thenReturn(failedMessages);
-
-        errorConsumer.readAndProcessErrorTopic(data, 0L, 0, ERROR_CONSUMER_ID);
-
-        verify(slackMessagingService,  times(1)).sendMessage(failedMessages);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImplTest.java
@@ -50,7 +50,7 @@ class ErrorConsumerImplTest {
         data.setAttempt(0);
         errorConsumer.readAndProcessErrorTopic(data, 0L, 0, ERROR_CONSUMER_ID);
 
-        verify(messageProcessorService, times(1)).processMessage(ERROR_CONSUMER_ID, data, failedMessageIds);
+        verify(messageProcessorService, times(1)).processMessage(ERROR_CONSUMER_ID, data, null);
         verify(slackMessagingService,  never()).sendMessage(failedMessageIds);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImplTest.java
@@ -47,11 +47,11 @@ class ErrorConsumerImplTest {
 
     @Test
     void readAndProcessErrorTopic() {
-        List<String> failedMessages = new ArrayList<>();
+        List<String> failedMessageIds = new ArrayList<>();
         data.setAttempt(0);
         errorConsumer.readAndProcessErrorTopic(data, 0L, 0, ERROR_CONSUMER_ID);
 
-        verify(messageProcessorService, times(1)).processMessage(ERROR_CONSUMER_ID, data, failedMessages);
-        verify(slackMessagingService,  never()).sendMessage(failedMessages);
+        verify(messageProcessorService, times(1)).processMessage(ERROR_CONSUMER_ID, data, failedMessageIds);
+        verify(slackMessagingService,  never()).sendMessage(failedMessageIds);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImplTest.java
@@ -10,9 +10,6 @@ import uk.gov.companieshouse.chips.ChipsRestInterfacesSend;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.service.MessageProcessorService;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -41,10 +38,8 @@ class ErrorConsumerImplTest {
 
     @Test
     void readAndProcessErrorTopic() {
-        List<String> failedMessageIds = new ArrayList<>();
         data.setAttempt(0);
         errorConsumer.readAndProcessErrorTopic(data, 0L, 0, ERROR_CONSUMER_ID);
-
         verify(messageProcessorService, times(1)).processMessage(ERROR_CONSUMER_ID, data, null);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImplTest.java
@@ -14,7 +14,6 @@ import uk.gov.companieshouse.service.ServiceException;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -47,13 +46,12 @@ class ErrorConsumerImplTest {
     }
 
     @Test
-    void readAndProcessErrorTopic() throws ServiceException {
+    void readAndProcessErrorTopic() {
         List<String> failedMessages = new ArrayList<>();
         data.setAttempt(0);
         errorConsumer.readAndProcessErrorTopic(data, 0L, 0, ERROR_CONSUMER_ID);
 
-        Optional<List<String>> failedMessageOpt = Optional.of(new ArrayList<>());
-        verify(messageProcessorService, times(1)).processMessage(ERROR_CONSUMER_ID, data, failedMessageOpt);
+        verify(messageProcessorService, times(1)).processMessage(ERROR_CONSUMER_ID, data, failedMessages);
         verify(slackMessagingService,  never()).sendMessage(failedMessages);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/MainConsumerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/MainConsumerImplTest.java
@@ -86,13 +86,4 @@ class MainConsumerImplTest {
         verify(messageProcessorService, times(1)).processMessage(RETRY_CONSUMER_ID, secondData, failedMessageOpt);
         verify(slackMessagingService,  never()).sendMessage(failedMessageOpt.get());
     }
-
-    @Test
-    void readAndProcessRetryTopicWithFailedMessages() throws ServiceException {
-        messageList = Arrays.asList(data, secondData);
-        List<Long> offsets = Arrays.asList(0L, 1L);
-        List<Integer> partitions = Arrays.asList(0, 0);
-
-        mainConsumer.readAndProcessRetryTopic(messageList, offsets, partitions, RETRY_CONSUMER_ID);
-    }
 }

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/MainConsumerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/MainConsumerImplTest.java
@@ -10,7 +10,6 @@ import uk.gov.companieshouse.chips.ChipsRestInterfacesSend;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.service.MessageProcessorService;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.slack.SlackMessagingService;
-import uk.gov.companieshouse.service.ServiceException;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/MainConsumerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/MainConsumerImplTest.java
@@ -75,12 +75,12 @@ class MainConsumerImplTest {
         List<Long> offsets = Arrays.asList(0L, 1L);
         List<Integer> partitions = Arrays.asList(0, 0);
 
-        List<String> failedMessages = new ArrayList<>();
+        List<String> failedMessageIds = new ArrayList<>();
 
         mainConsumer.readAndProcessRetryTopic(messageList, offsets, partitions, RETRY_CONSUMER_ID);
 
-        verify(messageProcessorService, times(1)).processMessage(RETRY_CONSUMER_ID, data, failedMessages);
-        verify(messageProcessorService, times(1)).processMessage(RETRY_CONSUMER_ID, secondData, failedMessages);
-        verify(slackMessagingService,  never()).sendMessage(failedMessages);
+        verify(messageProcessorService, times(1)).processMessage(RETRY_CONSUMER_ID, data, failedMessageIds);
+        verify(messageProcessorService, times(1)).processMessage(RETRY_CONSUMER_ID, secondData, failedMessageIds);
+        verify(slackMessagingService,  never()).sendMessage(failedMessageIds);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/MainConsumerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/MainConsumerImplTest.java
@@ -9,14 +9,18 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.chips.ChipsRestInterfacesSend;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.service.MessageProcessorService;
+import uk.gov.companieshouse.chipsrestinterfacesconsumer.slack.SlackMessagingService;
 import uk.gov.companieshouse.service.ServiceException;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class MainConsumerImplTest {
@@ -31,6 +35,9 @@ class MainConsumerImplTest {
 
     @Mock
     private ApplicationLogger logger;
+
+    @Mock
+    private SlackMessagingService slackMessagingService;
 
     @InjectMocks
     private MainConsumerImpl mainConsumer;
@@ -69,9 +76,29 @@ class MainConsumerImplTest {
         messageList = Arrays.asList(data, secondData);
         List<Long> offsets = Arrays.asList(0L, 1L);
         List<Integer> partitions = Arrays.asList(0, 0);
+
+        List<String> failedMessages = new ArrayList<>();
+        when(messageProcessorService.getFailedMessages()).thenReturn(failedMessages);
+
         mainConsumer.readAndProcessRetryTopic(messageList, offsets, partitions, RETRY_CONSUMER_ID);
 
         verify(messageProcessorService, times(1)).processMessage(RETRY_CONSUMER_ID, data);
         verify(messageProcessorService, times(1)).processMessage(RETRY_CONSUMER_ID, secondData);
+        verify(slackMessagingService,  never()).sendMessage(failedMessages);
+    }
+
+    @Test
+    void readAndProcessRetryTopicWithFailedMessages() throws ServiceException {
+        messageList = Arrays.asList(data, secondData);
+        List<Long> offsets = Arrays.asList(0L, 1L);
+        List<Integer> partitions = Arrays.asList(0, 0);
+
+        List<String> failedMessages = new ArrayList<>();
+        failedMessages.add("abc-123");
+        when(messageProcessorService.getFailedMessages()).thenReturn(failedMessages);
+
+        mainConsumer.readAndProcessRetryTopic(messageList, offsets, partitions, RETRY_CONSUMER_ID);
+
+        verify(slackMessagingService,  times(1)).sendMessage(failedMessages);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImplTest.java
@@ -99,8 +99,7 @@ class MessageProcessorServiceImplTest {
         verify(chipsRestClient, times(1)).sendToChips(chipsRestInterfacesSend, CONSUMER_ID);
         verify(messageProducer, times(1)).writeToTopic(any(), eq(RETRY_TOPIC));
         verify(messageProducer, times(0)).writeToTopic(any(), eq(ERROR_TOPIC));
-        assertEquals(1, failedMessageIds.size());
-        assertEquals(MESSAGE_ID, failedMessageIds.get(0));
+        assertTrue(failedMessageIds.isEmpty());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImplTest.java
@@ -54,9 +54,6 @@ class MessageProcessorServiceImplTest {
     @Mock
     private ApplicationLogger logger;
 
-    @Mock
-    private SlackMessagingService slackMessagingService;
-
     @InjectMocks
     private MessageProcessorServiceImpl messageProcessorService;
 
@@ -85,7 +82,6 @@ class MessageProcessorServiceImplTest {
         verify(chipsRestClient, times(1)).sendToChips(chipsRestInterfacesSend, CONSUMER_ID);
         verify(messageProducer, times(0)).writeToTopic(any(), eq(RETRY_TOPIC));
         verify(messageProducer, times(0)).writeToTopic(any(), eq(ERROR_TOPIC));
-        verify(slackMessagingService, never()).sendMessage(any());
     }
 
     @Test
@@ -101,7 +97,6 @@ class MessageProcessorServiceImplTest {
         verify(chipsRestClient, times(1)).sendToChips(chipsRestInterfacesSend, CONSUMER_ID);
         verify(messageProducer, times(1)).writeToTopic(any(), eq(RETRY_TOPIC));
         verify(messageProducer, times(0)).writeToTopic(any(), eq(ERROR_TOPIC));
-        verify(slackMessagingService, times(1)).sendMessage(MESSAGE_ID);
     }
 
     @Test
@@ -123,7 +118,6 @@ class MessageProcessorServiceImplTest {
         assertEquals(1, chipsRestInterfacesSend.getAttempt());
         verify(messageProducer, times(1)).writeToTopic(chipsRestInterfacesSend, RETRY_TOPIC);
         verify(messageProducer, times(0)).writeToTopic(any(), eq(ERROR_TOPIC));
-        verify(slackMessagingService, never()).sendMessage(MESSAGE_ID);
     }
 
     @Test
@@ -149,7 +143,6 @@ class MessageProcessorServiceImplTest {
         assertEquals(1, chipsRestInterfacesSend.getAttempt());
         verify(messageProducer, times(1)).writeToTopic(chipsRestInterfacesSend, RETRY_TOPIC);
         verify(messageProducer, times(0)).writeToTopic(any(), eq(ERROR_TOPIC));
-        verify(slackMessagingService, never()).sendMessage(MESSAGE_ID);
     }
 
     @Test
@@ -176,7 +169,6 @@ class MessageProcessorServiceImplTest {
         assertEquals(1, chipsRestInterfacesSend.getAttempt());
         verify(messageProducer, times(1)).writeToTopic(chipsRestInterfacesSend, RETRY_TOPIC);
         verify(messageProducer, times(0)).writeToTopic(any(), eq(ERROR_TOPIC));
-        verify(slackMessagingService, never()).sendMessage(MESSAGE_ID);
     }
 
     @Test
@@ -201,7 +193,6 @@ class MessageProcessorServiceImplTest {
                 .errorContext(eq(MESSAGE_ID), eq("Maximum retry attempts " + MAX_RETRIES + " reached for this message"), eq(restClientException), mapArgumentCaptor.capture());
         verifyLogData(mapArgumentCaptor.getValue());
         verifyLogConsumerName(mapArgumentCaptor.getValue());
-        verify(slackMessagingService, times(1)).sendMessage(MESSAGE_ID);
 
         verify(messageProducer, times(0)).writeToTopic(any(), eq(RETRY_TOPIC));
         verify(messageProducer, times(1)).writeToTopic(chipsRestInterfacesSend, ERROR_TOPIC);

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImplTest.java
@@ -93,14 +93,14 @@ class MessageProcessorServiceImplTest {
         RuntimeException runtimeException = new RuntimeException("runtimeException");
         doThrow(runtimeException).when(chipsRestClient).sendToChips(chipsRestInterfacesSend, CONSUMER_ID);
 
-        List<String> failedMessages = new ArrayList<>();
-        messageProcessorService.processMessage(CONSUMER_ID, chipsRestInterfacesSend, failedMessages);
+        List<String> failedMessageIds = new ArrayList<>();
+        messageProcessorService.processMessage(CONSUMER_ID, chipsRestInterfacesSend, failedMessageIds);
 
         verify(chipsRestClient, times(1)).sendToChips(chipsRestInterfacesSend, CONSUMER_ID);
         verify(messageProducer, times(1)).writeToTopic(any(), eq(RETRY_TOPIC));
         verify(messageProducer, times(0)).writeToTopic(any(), eq(ERROR_TOPIC));
-        assertEquals(1, failedMessages.size());
-        assertEquals(MESSAGE_ID, failedMessages.get(0));
+        assertEquals(1, failedMessageIds.size());
+        assertEquals(MESSAGE_ID, failedMessageIds.get(0));
     }
 
     @Test
@@ -108,8 +108,8 @@ class MessageProcessorServiceImplTest {
         RuntimeException runtimeException = new RuntimeException("runtimeException");
         doThrow(runtimeException).when(chipsRestClient).sendToChips(chipsRestInterfacesSend, CONSUMER_ID);
 
-        List<String> failedMessages = new ArrayList<>();
-        messageProcessorService.processMessage(CONSUMER_ID, chipsRestInterfacesSend, failedMessages);
+        List<String> failedMessageIds = new ArrayList<>();
+        messageProcessorService.processMessage(CONSUMER_ID, chipsRestInterfacesSend, failedMessageIds);
 
         verify(chipsRestClient, times(1)).sendToChips(chipsRestInterfacesSend, CONSUMER_ID);
         verify(logger, times(1)).errorContext(eq(MESSAGE_ID), eq(CHIPS_ERROR_MESSAGE), eq(runtimeException), mapArgumentCaptor.capture());
@@ -123,7 +123,7 @@ class MessageProcessorServiceImplTest {
         assertEquals(1, chipsRestInterfacesSend.getAttempt());
         verify(messageProducer, times(1)).writeToTopic(chipsRestInterfacesSend, RETRY_TOPIC);
         verify(messageProducer, times(0)).writeToTopic(any(), eq(ERROR_TOPIC));
-        assertTrue(failedMessages.isEmpty());
+        assertTrue(failedMessageIds.isEmpty());
     }
 
     @Test
@@ -131,8 +131,8 @@ class MessageProcessorServiceImplTest {
         HttpClientErrorException httpClientErrorException = new HttpClientErrorException(HttpStatus.BAD_GATEWAY);
         doThrow(httpClientErrorException).when(chipsRestClient).sendToChips(chipsRestInterfacesSend, CONSUMER_ID);
 
-        List<String> failedMessages = new ArrayList<>();
-        messageProcessorService.processMessage(CONSUMER_ID, chipsRestInterfacesSend, failedMessages);
+        List<String> failedMessageIds = new ArrayList<>();
+        messageProcessorService.processMessage(CONSUMER_ID, chipsRestInterfacesSend, failedMessageIds);
 
         verify(chipsRestClient, times(1)).sendToChips(chipsRestInterfacesSend, CONSUMER_ID);
         verify(logger, times(1)).errorContext(eq(MESSAGE_ID), eq(CHIPS_ERROR_MESSAGE), eq(httpClientErrorException), mapArgumentCaptor.capture());
@@ -150,7 +150,7 @@ class MessageProcessorServiceImplTest {
         assertEquals(1, chipsRestInterfacesSend.getAttempt());
         verify(messageProducer, times(1)).writeToTopic(chipsRestInterfacesSend, RETRY_TOPIC);
         verify(messageProducer, times(0)).writeToTopic(any(), eq(ERROR_TOPIC));
-        assertTrue(failedMessages.isEmpty());
+        assertTrue(failedMessageIds.isEmpty());
     }
 
     @Test
@@ -158,8 +158,8 @@ class MessageProcessorServiceImplTest {
         HttpServerErrorException httpServerErrorException = new HttpServerErrorException(HttpStatus.BAD_GATEWAY);
         doThrow(httpServerErrorException).when(chipsRestClient).sendToChips(chipsRestInterfacesSend, CONSUMER_ID);
 
-        List<String> failedMessages = new ArrayList<>();
-        messageProcessorService.processMessage(CONSUMER_ID, chipsRestInterfacesSend, failedMessages);
+        List<String> failedMessageIds = new ArrayList<>();
+        messageProcessorService.processMessage(CONSUMER_ID, chipsRestInterfacesSend, failedMessageIds);
 
         verify(chipsRestClient, times(1)).sendToChips(chipsRestInterfacesSend, CONSUMER_ID);
         verify(logger, times(1)).errorContext(eq(MESSAGE_ID),
@@ -178,7 +178,7 @@ class MessageProcessorServiceImplTest {
         assertEquals(1, chipsRestInterfacesSend.getAttempt());
         verify(messageProducer, times(1)).writeToTopic(chipsRestInterfacesSend, RETRY_TOPIC);
         verify(messageProducer, times(0)).writeToTopic(any(), eq(ERROR_TOPIC));
-        assertTrue(failedMessages.isEmpty());
+        assertTrue(failedMessageIds.isEmpty());
     }
 
     @Test
@@ -187,8 +187,8 @@ class MessageProcessorServiceImplTest {
         RestClientException restClientException = new RestClientException("restClientException");
         doThrow(restClientException).when(chipsRestClient).sendToChips(chipsRestInterfacesSend, CONSUMER_ID);
 
-        List<String> failedMessages = new ArrayList<>();
-        messageProcessorService.processMessage(CONSUMER_ID, chipsRestInterfacesSend, failedMessages);
+        List<String> failedMessageIds = new ArrayList<>();
+        messageProcessorService.processMessage(CONSUMER_ID, chipsRestInterfacesSend, failedMessageIds);
 
         verify(chipsRestClient, times(1)).sendToChips(chipsRestInterfacesSend, CONSUMER_ID);
         verify(messageProducer, times(0)).writeToTopic(chipsRestInterfacesSend, RETRY_TOPIC);
@@ -208,8 +208,8 @@ class MessageProcessorServiceImplTest {
         verify(messageProducer, times(0)).writeToTopic(any(), eq(RETRY_TOPIC));
         verify(messageProducer, times(1)).writeToTopic(chipsRestInterfacesSend, ERROR_TOPIC);
 
-        assertEquals(1, failedMessages.size());
-        assertEquals(MESSAGE_ID, failedMessages.get(0));
+        assertEquals(1, failedMessageIds.size());
+        assertEquals(MESSAGE_ID, failedMessageIds.get(0));
 
     }
 

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImplTest.java
@@ -21,7 +21,6 @@ import uk.gov.companieshouse.chipsrestinterfacesconsumer.producer.MessageProduce
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -79,7 +78,7 @@ class MessageProcessorServiceImplTest {
     void processMessageTest() {
         ChipsRestInterfacesSend chipsRestInterfacesSend = new ChipsRestInterfacesSend();
 
-        messageProcessorService.processMessage(CONSUMER_ID, chipsRestInterfacesSend, Optional.empty());
+        messageProcessorService.processMessage(CONSUMER_ID, chipsRestInterfacesSend, null);
 
         verify(chipsRestClient, times(1)).sendToChips(chipsRestInterfacesSend, CONSUMER_ID);
         verify(messageProducer, times(0)).writeToTopic(any(), eq(RETRY_TOPIC));
@@ -94,14 +93,14 @@ class MessageProcessorServiceImplTest {
         RuntimeException runtimeException = new RuntimeException("runtimeException");
         doThrow(runtimeException).when(chipsRestClient).sendToChips(chipsRestInterfacesSend, CONSUMER_ID);
 
-        Optional<List<String>> failedMessageOpt = Optional.of(new ArrayList<>());
-        messageProcessorService.processMessage(CONSUMER_ID, chipsRestInterfacesSend, failedMessageOpt);
+        List<String> failedMessages = new ArrayList<>();
+        messageProcessorService.processMessage(CONSUMER_ID, chipsRestInterfacesSend, failedMessages);
 
         verify(chipsRestClient, times(1)).sendToChips(chipsRestInterfacesSend, CONSUMER_ID);
         verify(messageProducer, times(1)).writeToTopic(any(), eq(RETRY_TOPIC));
         verify(messageProducer, times(0)).writeToTopic(any(), eq(ERROR_TOPIC));
-        assertEquals(1, failedMessageOpt.get().size());
-        assertEquals(MESSAGE_ID, failedMessageOpt.get().get(0));
+        assertEquals(1, failedMessages.size());
+        assertEquals(MESSAGE_ID, failedMessages.get(0));
     }
 
     @Test
@@ -109,8 +108,8 @@ class MessageProcessorServiceImplTest {
         RuntimeException runtimeException = new RuntimeException("runtimeException");
         doThrow(runtimeException).when(chipsRestClient).sendToChips(chipsRestInterfacesSend, CONSUMER_ID);
 
-        Optional<List<String>> failedMessageOpt = Optional.of(new ArrayList<>());
-        messageProcessorService.processMessage(CONSUMER_ID, chipsRestInterfacesSend, failedMessageOpt);
+        List<String> failedMessages = new ArrayList<>();
+        messageProcessorService.processMessage(CONSUMER_ID, chipsRestInterfacesSend, failedMessages);
 
         verify(chipsRestClient, times(1)).sendToChips(chipsRestInterfacesSend, CONSUMER_ID);
         verify(logger, times(1)).errorContext(eq(MESSAGE_ID), eq(CHIPS_ERROR_MESSAGE), eq(runtimeException), mapArgumentCaptor.capture());
@@ -124,7 +123,7 @@ class MessageProcessorServiceImplTest {
         assertEquals(1, chipsRestInterfacesSend.getAttempt());
         verify(messageProducer, times(1)).writeToTopic(chipsRestInterfacesSend, RETRY_TOPIC);
         verify(messageProducer, times(0)).writeToTopic(any(), eq(ERROR_TOPIC));
-        assertTrue(failedMessageOpt.get().isEmpty());
+        assertTrue(failedMessages.isEmpty());
     }
 
     @Test
@@ -132,8 +131,8 @@ class MessageProcessorServiceImplTest {
         HttpClientErrorException httpClientErrorException = new HttpClientErrorException(HttpStatus.BAD_GATEWAY);
         doThrow(httpClientErrorException).when(chipsRestClient).sendToChips(chipsRestInterfacesSend, CONSUMER_ID);
 
-        Optional<List<String>> failedMessageOpt = Optional.of(new ArrayList<>());
-        messageProcessorService.processMessage(CONSUMER_ID, chipsRestInterfacesSend, failedMessageOpt);
+        List<String> failedMessages = new ArrayList<>();
+        messageProcessorService.processMessage(CONSUMER_ID, chipsRestInterfacesSend, failedMessages);
 
         verify(chipsRestClient, times(1)).sendToChips(chipsRestInterfacesSend, CONSUMER_ID);
         verify(logger, times(1)).errorContext(eq(MESSAGE_ID), eq(CHIPS_ERROR_MESSAGE), eq(httpClientErrorException), mapArgumentCaptor.capture());
@@ -151,7 +150,7 @@ class MessageProcessorServiceImplTest {
         assertEquals(1, chipsRestInterfacesSend.getAttempt());
         verify(messageProducer, times(1)).writeToTopic(chipsRestInterfacesSend, RETRY_TOPIC);
         verify(messageProducer, times(0)).writeToTopic(any(), eq(ERROR_TOPIC));
-        assertTrue(failedMessageOpt.get().isEmpty());
+        assertTrue(failedMessages.isEmpty());
     }
 
     @Test
@@ -159,8 +158,8 @@ class MessageProcessorServiceImplTest {
         HttpServerErrorException httpServerErrorException = new HttpServerErrorException(HttpStatus.BAD_GATEWAY);
         doThrow(httpServerErrorException).when(chipsRestClient).sendToChips(chipsRestInterfacesSend, CONSUMER_ID);
 
-        Optional<List<String>> failedMessageOpt = Optional.of(new ArrayList<>());
-        messageProcessorService.processMessage(CONSUMER_ID, chipsRestInterfacesSend, failedMessageOpt);
+        List<String> failedMessages = new ArrayList<>();
+        messageProcessorService.processMessage(CONSUMER_ID, chipsRestInterfacesSend, failedMessages);
 
         verify(chipsRestClient, times(1)).sendToChips(chipsRestInterfacesSend, CONSUMER_ID);
         verify(logger, times(1)).errorContext(eq(MESSAGE_ID),
@@ -179,7 +178,7 @@ class MessageProcessorServiceImplTest {
         assertEquals(1, chipsRestInterfacesSend.getAttempt());
         verify(messageProducer, times(1)).writeToTopic(chipsRestInterfacesSend, RETRY_TOPIC);
         verify(messageProducer, times(0)).writeToTopic(any(), eq(ERROR_TOPIC));
-        assertTrue(failedMessageOpt.get().isEmpty());
+        assertTrue(failedMessages.isEmpty());
     }
 
     @Test
@@ -188,8 +187,8 @@ class MessageProcessorServiceImplTest {
         RestClientException restClientException = new RestClientException("restClientException");
         doThrow(restClientException).when(chipsRestClient).sendToChips(chipsRestInterfacesSend, CONSUMER_ID);
 
-        Optional<List<String>> failedMessageOpt = Optional.of(new ArrayList<>());
-        messageProcessorService.processMessage(CONSUMER_ID, chipsRestInterfacesSend, failedMessageOpt);
+        List<String> failedMessages = new ArrayList<>();
+        messageProcessorService.processMessage(CONSUMER_ID, chipsRestInterfacesSend, failedMessages);
 
         verify(chipsRestClient, times(1)).sendToChips(chipsRestInterfacesSend, CONSUMER_ID);
         verify(messageProducer, times(0)).writeToTopic(chipsRestInterfacesSend, RETRY_TOPIC);
@@ -209,8 +208,8 @@ class MessageProcessorServiceImplTest {
         verify(messageProducer, times(0)).writeToTopic(any(), eq(RETRY_TOPIC));
         verify(messageProducer, times(1)).writeToTopic(chipsRestInterfacesSend, ERROR_TOPIC);
 
-        assertEquals(1, failedMessageOpt.get().size());
-        assertEquals(MESSAGE_ID, failedMessageOpt.get().get(0));
+        assertEquals(1, failedMessages.size());
+        assertEquals(MESSAGE_ID, failedMessages.get(0));
 
     }
 

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImplTest.java
@@ -64,7 +64,7 @@ class SlackMessagingServiceImplTest {
     }
 
     private List<String> buildDummyFailedMessages() {
-        List<String> failedMessageIds = new ArrayList<String>();
+        List<String> failedMessageIds = new ArrayList<>();
         failedMessageIds.add("abc-123");
         failedMessageIds.add("cde-345");
         failedMessageIds.add("efg-567");

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImplTest.java
@@ -51,7 +51,7 @@ class SlackMessagingServiceImplTest {
         ChatPostMessageResponse chatPostMessageResponse = buildDummyResponse(false);
         doReturn(chatPostMessageResponse).when(slackMessagingServiceImpl).postSlackMessage(any(), any());
         slackMessagingServiceImpl.sendMessage(buildDummyFailedMessages());
-        verify(logger).info(String.format("Error message sent but received response: %s",
+        verify(logger).error(String.format("Error message sent but received response: %s",
                 chatPostMessageResponse.getError()));
     }
 

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImplTest.java
@@ -36,7 +36,6 @@ class SlackMessagingServiceImplTest {
     @BeforeEach
     void init() {
         ReflectionTestUtils.setField(slackMessagingServiceImpl,"slackChannel", SLACK_CHANNEL);
-        ReflectionTestUtils.setField(slackMessagingServiceImpl,"inErrorMode", false);
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImplTest.java
@@ -15,7 +15,6 @@ import static org.mockito.Mockito.verify;
 class SlackMessagingServiceImplTest {
 
     private static final String SLACK_CHANNEL = "Test Channel";
-    public static final String KAFKA_MESSAGE_ID = "testMessage";
     public static final String SLACK_ERROR_MESSAGE = "In %s mode, this is a test for message %s";
 
     @Mock
@@ -29,7 +28,7 @@ class SlackMessagingServiceImplTest {
         ReflectionTestUtils.setField(slackMessagingServiceImpl,"slackChannel", SLACK_CHANNEL);
         ReflectionTestUtils.setField(slackMessagingServiceImpl,"inErrorMode", false);
         ReflectionTestUtils.setField(slackMessagingServiceImpl,"slackErrorMessage", SLACK_ERROR_MESSAGE);
-        slackMessagingServiceImpl.sendMessage(KAFKA_MESSAGE_ID);
-        verify(logger).infoContext(KAFKA_MESSAGE_ID, String.format("Message sent to: %s", SLACK_CHANNEL));
+        //slackMessagingServiceImpl.sendMessage();
+        //verify(logger).infoContext(KAFKA_MESSAGE_ID, String.format("Message sent to: %s", SLACK_CHANNEL));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImplTest.java
@@ -1,0 +1,37 @@
+package uk.gov.companieshouse.chipsrestinterfacesconsumer.slack.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger;
+import uk.gov.companieshouse.chipsrestinterfacesconsumer.slack.SlackMessagingService;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class SlackMessagingServiceImplTest {
+
+    private static final String SLACK_CHANNEL = "Test Channel";
+    public static final String KAFKA_MESSAGE_ID = "testMessage";
+    public static final String ERROR_MESSAGE = "This is a test error";
+
+    private SlackMessagingService slackMessagingService;
+
+    @Autowired
+    ApplicationLogger logger;
+
+    @BeforeEach
+    void init() {
+        slackMessagingService = new SlackMessagingServiceImpl(logger);
+        ReflectionTestUtils.setField(slackMessagingService,"slackChannel", SLACK_CHANNEL);
+    }
+
+    @Test
+    void test() {
+        slackMessagingService.sendMessage(KAFKA_MESSAGE_ID, ERROR_MESSAGE);
+        verify(logger).infoContext(KAFKA_MESSAGE_ID, String.format("Message sent to: %s", SLACK_CHANNEL));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImplTest.java
@@ -1,10 +1,10 @@
 package uk.gov.companieshouse.chipsrestinterfacesconsumer.slack.impl;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.slack.SlackMessagingService;
@@ -16,22 +16,20 @@ class SlackMessagingServiceImplTest {
 
     private static final String SLACK_CHANNEL = "Test Channel";
     public static final String KAFKA_MESSAGE_ID = "testMessage";
-    public static final String ERROR_MESSAGE = "This is a test error";
+    public static final String SLACK_ERROR_MESSAGE = "In %s mode, this is a test for message %s";
 
-    private SlackMessagingService slackMessagingService;
+    @Mock
+    private ApplicationLogger logger;
 
-    @Autowired
-    ApplicationLogger logger;
-
-    @BeforeEach
-    void init() {
-        slackMessagingService = new SlackMessagingServiceImpl(logger);
-        ReflectionTestUtils.setField(slackMessagingService,"slackChannel", SLACK_CHANNEL);
-    }
+    @InjectMocks
+    private SlackMessagingServiceImpl slackMessagingServiceImpl;
 
     @Test
     void test() {
-        slackMessagingService.sendMessage(KAFKA_MESSAGE_ID, ERROR_MESSAGE);
+        ReflectionTestUtils.setField(slackMessagingServiceImpl,"slackChannel", SLACK_CHANNEL);
+        ReflectionTestUtils.setField(slackMessagingServiceImpl,"inErrorMode", false);
+        ReflectionTestUtils.setField(slackMessagingServiceImpl,"slackErrorMessage", SLACK_ERROR_MESSAGE);
+        slackMessagingServiceImpl.sendMessage(KAFKA_MESSAGE_ID);
         verify(logger).infoContext(KAFKA_MESSAGE_ID, String.format("Message sent to: %s", SLACK_CHANNEL));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImplTest.java
@@ -4,7 +4,6 @@ import com.slack.api.methods.MethodsClient;
 import com.slack.api.methods.SlackApiException;
 import com.slack.api.methods.request.chat.ChatPostMessageRequest;
 import com.slack.api.methods.response.chat.ChatPostMessageResponse;
-import okhttp3.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImplTest.java
@@ -1,5 +1,11 @@
 package uk.gov.companieshouse.chipsrestinterfacesconsumer.slack.impl;
 
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+import com.slack.api.methods.response.chat.ChatPostMessageResponse;
+import okhttp3.Response;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -7,28 +13,75 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger;
-import uk.gov.companieshouse.chipsrestinterfacesconsumer.slack.SlackMessagingService;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class SlackMessagingServiceImplTest {
 
     private static final String SLACK_CHANNEL = "Test Channel";
-    public static final String SLACK_ERROR_MESSAGE = "In %s mode, this is a test for message %s";
 
     @Mock
     private ApplicationLogger logger;
 
+    @Mock
+    private MethodsClient methods;
+
     @InjectMocks
     private SlackMessagingServiceImpl slackMessagingServiceImpl;
 
-    @Test
-    void test() {
+    @BeforeEach
+    void init() {
         ReflectionTestUtils.setField(slackMessagingServiceImpl,"slackChannel", SLACK_CHANNEL);
         ReflectionTestUtils.setField(slackMessagingServiceImpl,"inErrorMode", false);
-        ReflectionTestUtils.setField(slackMessagingServiceImpl,"slackErrorMessage", SLACK_ERROR_MESSAGE);
-        //slackMessagingServiceImpl.sendMessage();
-        //verify(logger).infoContext(KAFKA_MESSAGE_ID, String.format("Message sent to: %s", SLACK_CHANNEL));
+        ReflectionTestUtils.setField(slackMessagingServiceImpl,"methods", methods);
+    }
+
+    @Test
+    void testSuccessfulSlackMessage() throws IOException, SlackApiException {
+        when(methods.chatPostMessage(any(ChatPostMessageRequest.class))).thenReturn(buildDummyResponse(true));
+        slackMessagingServiceImpl.sendMessage(buildDummyFailedMessages());
+        verify(logger).info(String.format("Message sent to: %s", SLACK_CHANNEL));
+    }
+
+    @Test
+    void testFailedSlackMessage() throws IOException, SlackApiException {
+        ChatPostMessageResponse chatPostMessageResponse = buildDummyResponse(false);
+        when(methods.chatPostMessage(any(ChatPostMessageRequest.class))).thenReturn(chatPostMessageResponse);
+        slackMessagingServiceImpl.sendMessage(buildDummyFailedMessages());
+        verify(logger).info(String.format("Error message sent but received response: %s",
+                chatPostMessageResponse.getError()));
+    }
+
+    @Test
+    void testFailedSlackMessageWithIOException() throws IOException, SlackApiException {
+        IOException io = new IOException(null, null);
+        doThrow(io).when(methods).chatPostMessage(any(ChatPostMessageRequest.class));
+        slackMessagingServiceImpl.sendMessage(buildDummyFailedMessages());
+        verify(logger).errorContext("Slack error message not sent", io);
+    }
+
+    private List<String> buildDummyFailedMessages() {
+        List<String> failedMessages = new ArrayList<String>();
+        failedMessages.add("abc-123");
+        failedMessages.add("cde-345");
+        failedMessages.add("efg-567");
+        return failedMessages;
+    }
+
+    private ChatPostMessageResponse buildDummyResponse(boolean ok)  {
+        ChatPostMessageResponse response = new ChatPostMessageResponse();
+        response.setOk(ok);
+        if (!ok) {
+            response.setError("This is a test error");
+        }
+        return response;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImplTest.java
@@ -64,11 +64,11 @@ class SlackMessagingServiceImplTest {
     }
 
     private List<String> buildDummyFailedMessages() {
-        List<String> failedMessages = new ArrayList<String>();
-        failedMessages.add("abc-123");
-        failedMessages.add("cde-345");
-        failedMessages.add("efg-567");
-        return failedMessages;
+        List<String> failedMessageIds = new ArrayList<String>();
+        failedMessageIds.add("abc-123");
+        failedMessageIds.add("cde-345");
+        failedMessageIds.add("efg-567");
+        return failedMessageIds;
     }
 
     private ChatPostMessageResponse buildDummyResponse(boolean ok)  {


### PR DESCRIPTION
The acceptence criteria are open to interpretation and it is unclear:

- What the content of the slack message should be
- When exactly to send a slack message. Although it says "any error messages created by the new CHS resilience service  to be automatically sent to us via a Slack message" this would result in potentially hundreds of slack messages being sent at the same time if we were to assume that this meant all error messages logged in the code.
 

Opted for collecting failed kafka message ids and sending a slack message once the kafka messages have been looped through and processed to cut down on the amount of slack messages sent bearing this in mind regarding the licence terms:

"you will not...attempt to use our APIs in a manner that exceeds rate limits, or constitutes excessive or abusive usage."

see: https://slack.com/intl/en-gb/terms-of-service/api if interested.

"Failed" is based on all retries being attempted as spceified by the MAX_RETRY_ATTEMPTS if all are exhausted then the message id is added to a list/vector of failed kafka messages ready to be added to the slack message once the loop is complete. This an example of a  resulting slack message:

<img width="424" alt="Screen Shot 2021-02-25 at 09 59 49" src="https://user-images.githubusercontent.com/38655987/109136677-46921580-7750-11eb-9cf6-07b9e3289a92.png">

You may notice that the sender is shown as being myself - this is because the app set up to send messages has only myself as a collaborator:
https://app.slack.com/app-settings/T0PG7HQTV/A01P5ER99H8/collaborators

A final sender can be decided upon - we might need a new slack user for this.