### PR TITLE
BI-6999 stop error consumer consuming when all messages present at app start are consumed

### DIFF
--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/ApplicationConfig.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/ApplicationConfig.java
@@ -5,11 +5,19 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.Instant;
+import java.util.function.Supplier;
+
 @Configuration
 class ApplicationConfig {
 
     @Bean
     RestTemplate restTemplate(RestTemplateBuilder builder) {
         return builder.build();
+    }
+
+    @Bean
+    public Supplier<Long> timestampNow() {
+        return () -> Instant.now().toEpochMilli();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/KafkaConsumerConfig.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/KafkaConsumerConfig.java
@@ -12,9 +12,7 @@ import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import uk.gov.companieshouse.chips.ChipsRestInterfacesSend;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.avro.AvroDeserializer;
 
-import java.sql.Timestamp;
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/KafkaProducerConfig.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/KafkaProducerConfig.java
@@ -21,9 +21,6 @@ public class KafkaProducerConfig {
     @Value("${kafka.broker.address}")
     private String brokerAddress;
 
-    @Value("${kafka.producer.retries}")
-    private int retries;
-
     @Value("${kafka.producer.batch.size.bytes}")
     private int batchSizeBytes;
 

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImpl.java
@@ -44,7 +44,7 @@ public class ErrorConsumerImpl implements ErrorConsumer {
      * @param groupId The group id of the consumer
      */
     @Override
-    @KafkaListener(topics = "${kafka.error.topic}", containerFactory = "kafkaListenerContainerFactory", groupId = "error-group")
+    @KafkaListener(topics = "${kafka.error.topic}", containerFactory = "kafkaErrorListenerContainerFactory", groupId = "error-group")
     public void readAndProcessErrorTopic(@Payload ChipsRestInterfacesSend data,
                                          @Header(KafkaHeaders.OFFSET) Long offset,
                                          @Header(KafkaHeaders.RECEIVED_PARTITION_ID) Integer partition,

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/MainConsumerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/MainConsumerImpl.java
@@ -95,7 +95,7 @@ public class MainConsumerImpl implements MainConsumer {
 
         logger.infoContext(messageId, String.format("%s: Consumed Message from Partition: %s, Offset: %s", consumerId, partition, offset), logMap);
         logger.infoContext(messageId, String.format("received data='%s'", data), logMap);
-        logger.infoContext(messageId, String.format("%s: Finished Processing Message from Partition: %s, Offset: %s", consumerId, partition, offset), logMap);
         messageProcessorService.processMessage(consumerId, data);
+        logger.infoContext(messageId, String.format("%s: Finished Processing Message from Partition: %s, Offset: %s", consumerId, partition, offset), logMap);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/KafkaConsumerConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/KafkaConsumerConfigTest.java
@@ -1,26 +1,48 @@
 package uk.gov.companieshouse.chipsrestinterfacesconsumer.configuration;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.listener.adapter.RecordFilterStrategy;
 import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.companieshouse.chips.ChipsRestInterfacesSend;
+
+import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class KafkaConsumerConfigTest {
 
     private static final String BROKER_ADDRESS = "BROKER";
     private static final long RETRY_THROTTLE_SECONDS = 5000L;
     private static final int MAX_RETRY_ATTEMPTS = 5;
+    private static final Long TIMESTAMP_PAST = 1614693284647L;
+    private static final Long TIMESTAMP_NOW = 1614693285647L;
+    private static final Long TIMESTAMP_FUTURE = 1614693286647L;
 
+    @Mock
+    private ConsumerRecord<String, ChipsRestInterfacesSend> mockConsumerRecord;
+
+    @Mock
+    private Supplier<Long> mockTimestampNow;
+
+    @InjectMocks
     private KafkaConsumerConfig kafkaConsumerConfig;
 
     @BeforeEach
     void init() {
-        kafkaConsumerConfig = new KafkaConsumerConfig();
         ReflectionTestUtils.setField(kafkaConsumerConfig, "brokerAddress", BROKER_ADDRESS);
         ReflectionTestUtils.setField(kafkaConsumerConfig, "retryThrottleSeconds", RETRY_THROTTLE_SECONDS);
-        ReflectionTestUtils.setField(kafkaConsumerConfig, "maxRetryAttempts", MAX_RETRY_ATTEMPTS);
     }
 
     @Test
@@ -49,5 +71,50 @@ class KafkaConsumerConfigTest {
         var factory = kafkaConsumerConfig.kafkaRetryListenerContainerFactory();
         assertEquals(retryInterval * 1000L, factory.getContainerProperties().getIdleBetweenPolls());
         assertEquals(300000, factory.getConsumerFactory().getConfigurationProperties().get(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG));
+    }
+
+    @Test
+    void kafkaErrorListenerContainerFactoryDoesFilterNewRecords() {
+        when(mockTimestampNow.get()).thenReturn(TIMESTAMP_NOW);
+        var factory = kafkaConsumerConfig.kafkaErrorListenerContainerFactory();
+        @SuppressWarnings("unchecked")
+        var recordFilterStrategy = (RecordFilterStrategy<String, ChipsRestInterfacesSend>) ReflectionTestUtils.getField(factory, "recordFilterStrategy");
+        when(mockConsumerRecord.timestamp()).thenReturn(TIMESTAMP_FUTURE);
+
+        assertNotNull(recordFilterStrategy);
+
+        boolean isFiltered = recordFilterStrategy.filter(mockConsumerRecord);
+
+        assertTrue(isFiltered);
+    }
+
+    @Test
+    void kafkaErrorListenerContainerFactoryDoesNotFilterRecordsCreatedAtTheExactSameTimeTheAppStarted() {
+        when(mockTimestampNow.get()).thenReturn(TIMESTAMP_NOW);
+        var factory = kafkaConsumerConfig.kafkaErrorListenerContainerFactory();
+        @SuppressWarnings("unchecked")
+        var recordFilterStrategy = (RecordFilterStrategy<String, ChipsRestInterfacesSend>) ReflectionTestUtils.getField(factory, "recordFilterStrategy");
+        when(mockConsumerRecord.timestamp()).thenReturn(TIMESTAMP_NOW);
+
+        assertNotNull(recordFilterStrategy);
+
+        boolean isFiltered = recordFilterStrategy.filter(mockConsumerRecord);
+
+        assertFalse(isFiltered);
+    }
+
+    @Test
+    void kafkaErrorListenerContainerFactoryDoesNotFilterOldRecords() {
+        when(mockTimestampNow.get()).thenReturn(TIMESTAMP_NOW);
+        var factory = kafkaConsumerConfig.kafkaErrorListenerContainerFactory();
+        @SuppressWarnings("unchecked")
+        var recordFilterStrategy = (RecordFilterStrategy<String, ChipsRestInterfacesSend>) ReflectionTestUtils.getField(factory, "recordFilterStrategy");
+        when(mockConsumerRecord.timestamp()).thenReturn(TIMESTAMP_PAST);
+
+        assertNotNull(recordFilterStrategy);
+
+        boolean isFiltered = recordFilterStrategy.filter(mockConsumerRecord);
+
+        assertFalse(isFiltered);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/KafkaConsumerConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/KafkaConsumerConfigTest.java
@@ -37,6 +37,12 @@ class KafkaConsumerConfigTest {
     }
 
     @Test
+    void kafkaErrorListenerContainerFactory() {
+        var factory = kafkaConsumerConfig.kafkaErrorListenerContainerFactory();
+        assertEquals(0, factory.getContainerProperties().getIdleBetweenPolls());
+    }
+
+    @Test
     void kafkaRetryListenerContainerFactoryRetryLessThanDefaultPollInterval() {
         var retryInterval = 1L;
         ReflectionTestUtils.setField(kafkaConsumerConfig, "retryThrottleSeconds", retryInterval);


### PR DESCRIPTION
Adding filter strategy to a new error listener container factory config to filter out any messages with timestamps after the app started. Unable to test this on a dev environment as far as I know so will need to be checked in a test environment.