### PR TITLE
BI-7146 make error message processing use same message failure logic as main messages

### DIFF
--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImpl.java
@@ -51,7 +51,9 @@ public class ErrorConsumerImpl implements ErrorConsumer {
                                          @Header(KafkaHeaders.RECEIVED_PARTITION_ID) Integer partition,
                                          @Header(KafkaHeaders.GROUP_ID) String groupId){
 
+        data.setAttempt(0);
         var messageId = data.getMessageId();
+
         Map<String, Object> logMap = new HashMap<>();
         logMap.put("Group Id", groupId);
         logMap.put("Partition", partition);
@@ -59,8 +61,6 @@ public class ErrorConsumerImpl implements ErrorConsumer {
 
         logger.infoContext(messageId, String.format("%s: Consumed Message from Partition: %s, Offset: %s", groupId, partition, offset), logMap);
         logger.infoContext(messageId, String.format("received data='%s'", data), logMap);
-
-
         messageProcessorService.processMessage("error-consumer", data, null);
         logger.infoContext(messageId, String.format("%s: Finished Processing Message from Partition: %s, Offset: %s", groupId, partition, offset), logMap);
     }

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/MainConsumerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/MainConsumerImpl.java
@@ -98,6 +98,7 @@ public class MainConsumerImpl implements MainConsumer {
      * @param data a deserialized message from kafka
      * @param offset The offset of {@code data}
      * @param partition The partition of {@code data}
+     * @param failedMessageIds A list of message ids that have failed processing
      */
     private void processMessage(String consumerId,
                                 ChipsRestInterfacesSend data,

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImpl.java
@@ -28,9 +28,6 @@ public class MessageProcessorServiceImpl implements MessageProcessorService {
     @Value("${kafka.error.topic}")
     private String errorTopicName;
 
-    @Value("${RUN_APP_IN_ERROR_MODE:false}")
-    private boolean runAppInErrorMode;
-
     @Autowired
     private ChipsRestClient chipsRestClient;
 
@@ -66,15 +63,8 @@ public class MessageProcessorServiceImpl implements MessageProcessorService {
         var messageId = message.getMessageId();
         logger.errorContext(messageId, SEND_FAILURE_MESSAGE, e, logMap);
 
-        if (runAppInErrorMode) {
-            message.setAttempt(1);
-            messageProducer.writeToTopic(message, retryTopicName);
-            return;
-        }
-
         var attempts = message.getAttempt();
         logger.infoContext(messageId, String.format("Attempt %s failed for this message", attempts), logMap);
-
 
         if (attempts < maxRetryAttempts) {
             message.setAttempt(attempts + 1);

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/KafkaConsumerConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/KafkaConsumerConfigTest.java
@@ -25,7 +25,6 @@ class KafkaConsumerConfigTest {
 
     private static final String BROKER_ADDRESS = "BROKER";
     private static final long RETRY_THROTTLE_SECONDS = 5000L;
-    private static final int MAX_RETRY_ATTEMPTS = 5;
     private static final Long TIMESTAMP_PAST = 1614693284647L;
     private static final Long TIMESTAMP_NOW = 1614693285647L;
     private static final Long TIMESTAMP_FUTURE = 1614693286647L;

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImplTest.java
@@ -85,21 +85,6 @@ class MessageProcessorServiceImplTest {
     }
 
     @Test
-    void processErrorMessageTest() {
-        ChipsRestInterfacesSend chipsRestInterfacesSend = new ChipsRestInterfacesSend();
-        chipsRestInterfacesSend.setMessageId(MESSAGE_ID);
-        RuntimeException runtimeException = new RuntimeException("runtimeException");
-        doThrow(runtimeException).when(chipsRestClient).sendToChips(chipsRestInterfacesSend, CONSUMER_ID);
-
-        boolean result = messageProcessorService.processMessage(CONSUMER_ID, chipsRestInterfacesSend);
-
-        verify(chipsRestClient, times(1)).sendToChips(chipsRestInterfacesSend, CONSUMER_ID);
-        verify(messageProducer, times(1)).writeToTopic(any(), eq(RETRY_TOPIC));
-        verify(messageProducer, times(0)).writeToTopic(any(), eq(ERROR_TOPIC));
-        assertTrue(result);
-    }
-
-    @Test
     void testRetryIsCalled() {
         RuntimeException runtimeException = new RuntimeException("runtimeException");
         doThrow(runtimeException).when(chipsRestClient).sendToChips(chipsRestInterfacesSend, CONSUMER_ID);

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImplTest.java
@@ -66,7 +66,6 @@ class MessageProcessorServiceImplTest {
         ReflectionTestUtils.setField(messageProcessorService, "maxRetryAttempts", MAX_RETRIES);
         ReflectionTestUtils.setField(messageProcessorService, "retryTopicName", RETRY_TOPIC);
         ReflectionTestUtils.setField(messageProcessorService, "errorTopicName", ERROR_TOPIC);
-        ReflectionTestUtils.setField(messageProcessorService, "runAppInErrorMode", false);
 
         chipsRestInterfacesSend = new ChipsRestInterfacesSend();
         chipsRestInterfacesSend.setData(DUMMY_DATA);
@@ -87,7 +86,6 @@ class MessageProcessorServiceImplTest {
 
     @Test
     void processErrorMessageTest() {
-        ReflectionTestUtils.setField(messageProcessorService, "runAppInErrorMode", true);
         ChipsRestInterfacesSend chipsRestInterfacesSend = new ChipsRestInterfacesSend();
         chipsRestInterfacesSend.setMessageId(MESSAGE_ID);
         RuntimeException runtimeException = new RuntimeException("runtimeException");


### PR DESCRIPTION
Changing the messageProcessorService to treat messages from the error topic the same way we do the 'main' messages. The only difference between them really is the topic we consume from which is handled by the consumer classes. If they fail to be sent to chips then they get handled the same, ie. put on retry topic and the error topic if retries fail.