### PR TITLE
BI-6930 Implement use of manual acknowledgement of offsets

### DIFF
--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/KafkaConsumerConfig.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/configuration/KafkaConsumerConfig.java
@@ -10,6 +10,7 @@ import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
 import uk.gov.companieshouse.chips.ChipsRestInterfacesSend;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.avro.AvroDeserializer;
 
@@ -53,6 +54,9 @@ public class KafkaConsumerConfig {
         props.put(
                 ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
                 "earliest");
+        props.put(
+                ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG,
+                false);
         return props;
     }
 
@@ -91,6 +95,7 @@ public class KafkaConsumerConfig {
         ConcurrentKafkaListenerContainerFactory<String, ChipsRestInterfacesSend> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(newMainConsumerFactory());
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
         return factory;
     }
 
@@ -107,8 +112,11 @@ public class KafkaConsumerConfig {
         ConcurrentKafkaListenerContainerFactory<String, ChipsRestInterfacesSend> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(newRetryConsumerFactory());
-        factory.getContainerProperties().setIdleBetweenPolls(idleMillis);
         factory.setBatchListener(true);
+
+        ContainerProperties containerProperties = factory.getContainerProperties();
+        containerProperties.setIdleBetweenPolls(idleMillis);
+        containerProperties.setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
         return factory;
     }
 
@@ -126,6 +134,7 @@ public class KafkaConsumerConfig {
         factory.setConsumerFactory(newMainConsumerFactory());
         factory.setRecordFilterStrategy(consumerRecord -> appStartedTime < consumerRecord.timestamp());
         factory.setAckDiscarded(false);
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
         return factory;
     }
 

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/ErrorConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/ErrorConsumer.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.chipsrestinterfacesconsumer.consumer;
 
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.Payload;
@@ -7,6 +8,7 @@ import uk.gov.companieshouse.chips.ChipsRestInterfacesSend;
 
 public interface ErrorConsumer {
     void readAndProcessErrorTopic(@Payload ChipsRestInterfacesSend data,
+                                  Acknowledgment acknowledgment,
                                   @Header(KafkaHeaders.OFFSET) Long offset,
                                   @Header(KafkaHeaders.RECEIVED_PARTITION_ID) Integer partition,
                                   @Header(KafkaHeaders.GROUP_ID) String groupId);

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/MainConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/MainConsumer.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.chipsrestinterfacesconsumer.consumer;
 
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.Payload;
@@ -10,12 +11,14 @@ import java.util.List;
 public interface MainConsumer {
 
     void readAndProcessMainTopic(@Payload ChipsRestInterfacesSend data,
+                                 Acknowledgment acknowledgment,
                                  @Header(KafkaHeaders.OFFSET) Long offset,
                                  @Header(KafkaHeaders.RECEIVED_PARTITION_ID) Integer partition,
                                  @Header(KafkaHeaders.GROUP_ID) String groupId
     );
 
     void readAndProcessRetryTopic(@Payload List<ChipsRestInterfacesSend> messages,
+                                  Acknowledgment acknowledgment,
                                   @Header(KafkaHeaders.OFFSET) List<Long> offsets,
                                   @Header(KafkaHeaders.RECEIVED_PARTITION_ID) List<Integer> partitions,
                                   @Header(KafkaHeaders.GROUP_ID) String groupId

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImplTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
 import uk.gov.companieshouse.chips.ChipsRestInterfacesSend;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger;
 import uk.gov.companieshouse.chipsrestinterfacesconsumer.service.MessageProcessorService;
@@ -18,6 +19,9 @@ class ErrorConsumerImplTest {
 
     private static final String DATA = "DATA";
     private static final String ERROR_CONSUMER_ID = "error-consumer";
+
+    @Mock
+    private Acknowledgment acknowledgment;
 
     @Mock
     private MessageProcessorService messageProcessorService;
@@ -39,7 +43,9 @@ class ErrorConsumerImplTest {
     @Test
     void readAndProcessErrorTopic() {
         data.setAttempt(0);
-        errorConsumer.readAndProcessErrorTopic(data, 0L, 0, ERROR_CONSUMER_ID);
+        errorConsumer.readAndProcessErrorTopic(data, acknowledgment, 0L, 0, ERROR_CONSUMER_ID);
+
         verify(messageProcessorService, times(1)).processMessage(ERROR_CONSUMER_ID, data);
+        verify(acknowledgment, times(1)).acknowledge();
     }
 }

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/MainConsumerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/MainConsumerImplTest.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.chipsrestinterfacesconsumer.consumer.impl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -18,6 +19,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -89,10 +91,11 @@ class MainConsumerImplTest {
 
         mainConsumer.readAndProcessRetryTopic(messageList, acknowledgment, offsets, partitions, RETRY_CONSUMER_ID);
 
-        verify(messageProcessorService, times(1)).processMessage(RETRY_CONSUMER_ID, data);
-        verify(messageProcessorService, times(1)).processMessage(RETRY_CONSUMER_ID, secondData);
-        verify(slackMessagingService, never()).sendMessage(failedMessageIds);
-        verify(acknowledgment, times(1)).acknowledge();
+        InOrder retryOrder = inOrder(messageProcessorService, acknowledgment, slackMessagingService);
+        retryOrder.verify(messageProcessorService, times(1)).processMessage(RETRY_CONSUMER_ID, data);
+        retryOrder.verify(messageProcessorService, times(1)).processMessage(RETRY_CONSUMER_ID, secondData);
+        retryOrder.verify(acknowledgment, times(1)).acknowledge();
+        retryOrder.verify(slackMessagingService, never()).sendMessage(failedMessageIds);
     }
 
     @Test
@@ -126,9 +129,10 @@ class MainConsumerImplTest {
         failedMessageIds.add(SECOND_MESSAGE_ID);
         mainConsumer.readAndProcessRetryTopic(messageList, acknowledgment, offsets, partitions, RETRY_CONSUMER_ID);
 
-        verify(messageProcessorService, times(1)).processMessage(RETRY_CONSUMER_ID, data);
-        verify(messageProcessorService, times(1)).processMessage(RETRY_CONSUMER_ID, secondData);
-        verify(slackMessagingService, times(1)).sendMessage(failedMessageIds);
-        verify(acknowledgment, times(1)).acknowledge();
+        InOrder retryOrder = inOrder(messageProcessorService, acknowledgment, slackMessagingService);
+        retryOrder.verify(messageProcessorService, times(1)).processMessage(RETRY_CONSUMER_ID, data);
+        retryOrder.verify(messageProcessorService, times(1)).processMessage(RETRY_CONSUMER_ID, secondData);
+        retryOrder.verify(acknowledgment, times(1)).acknowledge();
+        retryOrder.verify(slackMessagingService, times(1)).sendMessage(failedMessageIds);
     }
 }


### PR DESCRIPTION
Adding manual acknowledgements to enable us to commit the offsets manual.
The down side is that for batch mode on the retry listener, spring only provides a single Acknowledgement to acknowledge the whole batch. 
So essentially it is working the same as before it's just that we say 'commit' instead of spring. However, it look like we need to use manual commits to enable us to implement the 'ignore messages with timestamp greater than start time' in the error consumer feature so it should be a small improvement.

Also, moved the collecting of failed message id's into the retry listener, as main doesn't need them (they were in the shared processMessage private method).