### PR TITLE
BI-6930 Using acknowledge.nack() to commit any processed messages in …

### DIFF
--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/common/ApplicationLogger.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/common/ApplicationLogger.java
@@ -17,6 +17,13 @@ import java.util.Map;
 @Component
 public class ApplicationLogger {
 
+    public static final String KEY_GROUP_ID = "Group Id";
+    public static final String KEY_PARTITION = "Partition";
+    public static final String KEY_OFFSET = "Offset";
+    public static final String KEY_MESSAGE = "Message";
+    public static final String KEY_MESSAGE_CONSUMER_ID = "Message Consumer ID";
+    public static final String KEY_HTTP_STATUS_CODE = "HTTP Status Code";
+
     private Logger logger;
 
     @Value("${RUN_APP_IN_ERROR_MODE:false}")
@@ -61,6 +68,10 @@ public class ApplicationLogger {
 
     public void errorContext(String context, Exception e) {
         logger.errorContext(context, e, null);
+    }
+
+    public void errorContext(String context, Exception e, Map<String, Object> dataMap) {
+        logger.errorContext(context, e, cloneMapData(dataMap));
     }
 
     public void errorContext(String context, String message, Exception e) {

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/consumer/impl/ErrorConsumerImpl.java
@@ -17,6 +17,10 @@ import javax.annotation.PostConstruct;
 import java.util.HashMap;
 import java.util.Map;
 
+import static uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger.KEY_GROUP_ID;
+import static uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger.KEY_OFFSET;
+import static uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger.KEY_PARTITION;
+
 @Service
 @ConditionalOnProperty(prefix = "feature", name = "errorMode", havingValue = "true")
 public class ErrorConsumerImpl implements ErrorConsumer {
@@ -57,9 +61,9 @@ public class ErrorConsumerImpl implements ErrorConsumer {
         var messageId = data.getMessageId();
 
         Map<String, Object> logMap = new HashMap<>();
-        logMap.put("Group Id", groupId);
-        logMap.put("Partition", partition);
-        logMap.put("Offset", offset);
+        logMap.put(KEY_GROUP_ID, groupId);
+        logMap.put(KEY_PARTITION, partition);
+        logMap.put(KEY_OFFSET, offset);
 
         logger.debugContext(messageId, acknowledgment.toString(), logMap);
 

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageProcessorServiceImpl.java
@@ -13,6 +13,10 @@ import uk.gov.companieshouse.chipsrestinterfacesconsumer.service.MessageProcesso
 import java.util.HashMap;
 import java.util.Map;
 
+import static uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger.KEY_HTTP_STATUS_CODE;
+import static uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger.KEY_MESSAGE;
+import static uk.gov.companieshouse.chipsrestinterfacesconsumer.common.ApplicationLogger.KEY_MESSAGE_CONSUMER_ID;
+
 @Service
 public class MessageProcessorServiceImpl implements MessageProcessorService {
 
@@ -38,15 +42,15 @@ public class MessageProcessorServiceImpl implements MessageProcessorService {
 
     @Override
     public boolean processMessage(String consumerId,
-                               ChipsRestInterfacesSend message) {
+                                  ChipsRestInterfacesSend message) {
 
         Map<String, Object> logMap = new HashMap<>();
-        logMap.put("Message", message.getData());
-        logMap.put("Message Consumer ID", consumerId);
+        logMap.put(KEY_MESSAGE, message.getData());
+        logMap.put(KEY_MESSAGE_CONSUMER_ID, consumerId);
         try {
             chipsRestClient.sendToChips(message, consumerId);
         } catch (HttpStatusCodeException hsce) {
-            logMap.put("HTTP Status Code", hsce.getStatusCode().toString());
+            logMap.put(KEY_HTTP_STATUS_CODE, hsce.getStatusCode().toString());
             return handleFailedMessage(message, hsce, logMap);
         } catch (Exception e) {
             return handleFailedMessage(message, e, logMap);
@@ -55,8 +59,8 @@ public class MessageProcessorServiceImpl implements MessageProcessorService {
     }
 
     private boolean handleFailedMessage(ChipsRestInterfacesSend message,
-                                     Exception e,
-                                     Map<String, Object> logMap) {
+                                        Exception e,
+                                        Map<String, Object> logMap) {
 
         var messageId = message.getMessageId();
         logger.errorContext(messageId, SEND_FAILURE_MESSAGE, e, logMap);


### PR DESCRIPTION
…the retry batch if we get an unexpected exception

Adding a catch exception into the retry processing loop to catch any unexpected exceptions. 
This will allow us to commit those messages already processed in the batch using acknowledge.nack(). We supply the index of the current message in the batch to this nack method. This commits offsets upto the supplied index, meaning that next time the poll() is called the first message will be the one that it failed on. Without this, if we do get a failure somewhere unexpected, the whole batch gets discarded and the same batch is supplied in the next poll(). So if we processed 10 messages in the batch before it failed, then those 10 get reprocessed again. Nack allows us to commit offsets of those messages in the batch that were processed.

the Nack also requires a sleep time be supplied before retrying the next batch. I've set this to be a config value but have set default to 1 second.