### PR TITLE
OBJ-514 Making any exceptions that go to errorHandler also get a slac…

### DIFF
--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/SlackMessagingService.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/SlackMessagingService.java
@@ -6,6 +6,6 @@ public interface SlackMessagingService {
 
     void sendErrorTopicMessage(List<String> failedMessageIds);
 
-    void sendDeserializationErrorMessage(String deserializationFailureMessage);
+    void sendRejectedErrorMessage(String deserializationFailureMessage);
 
 }

--- a/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImpl.java
@@ -47,8 +47,8 @@ public class SlackMessagingServiceImpl implements SlackMessagingService {
     }
 
     @Override
-    public void sendDeserializationErrorMessage(String deserializationFailureMessage) {
-       sendMessage(deserializationFailureMessage, "Deserialization error");
+    public void sendRejectedErrorMessage(String errorMessage) {
+       sendMessage(errorMessage, "Message rejected error");
     }
 
     ChatPostMessageResponse postSlackMessage(

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageRejectionServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageRejectionServiceImplTest.java
@@ -35,8 +35,8 @@ class MessageRejectionServiceImplTest {
         Exception exception = new Exception(new DeserializationException("", new byte[1], false, new SerializationException()));
         ConsumerRecord<?, ?> datum = new ConsumerRecord<>(TOPIC,1,1L, "", "");
         messageRejectionService.handleRejectedMessage(exception, datum);
-        String deserializationErrorMessage = "Failed to deserialize message - " + buildSingleMessage(TOPIC,1,1L);
-        verify(slackMessagingService, times(1)).sendDeserializationErrorMessage(deserializationErrorMessage);
+        String deserializationErrorMessage = "Message rejected - Failed to deserialize message - " + buildSingleMessage(TOPIC,1,1L);
+        verify(slackMessagingService, times(1)).sendRejectedErrorMessage(deserializationErrorMessage);
     }
 
     @Test
@@ -45,7 +45,7 @@ class MessageRejectionServiceImplTest {
         ConsumerRecord<?, ?> datum = new ConsumerRecord<>(TOPIC,1,1L, "", "");
         messageRejectionService.handleRejectedMessage(exception, datum);
         String deserializationErrorMessage = "Failed to deserialize message - " + buildSingleMessage(TOPIC,1,1L);
-        verify(slackMessagingService, never()).sendDeserializationErrorMessage(deserializationErrorMessage);
+        verify(slackMessagingService, never()).sendRejectedErrorMessage(deserializationErrorMessage);
     }
 
     private String buildSingleMessage(String topic, int partition, long offset) {

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageRejectionServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/service/impl/MessageRejectionServiceImplTest.java
@@ -44,8 +44,8 @@ class MessageRejectionServiceImplTest {
         Exception exception = new Exception();
         ConsumerRecord<?, ?> datum = new ConsumerRecord<>(TOPIC,1,1L, "", "");
         messageRejectionService.handleRejectedMessage(exception, datum);
-        String deserializationErrorMessage = "Failed to deserialize message - " + buildSingleMessage(TOPIC,1,1L);
-        verify(slackMessagingService, never()).sendRejectedErrorMessage(deserializationErrorMessage);
+        String errorMessage = "Message rejected - Kafka consumer message exception - " + buildSingleMessage(TOPIC,1,1L);
+        verify(slackMessagingService, times(1)).sendRejectedErrorMessage(errorMessage);
     }
 
     private String buildSingleMessage(String topic, int partition, long offset) {

--- a/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chipsrestinterfacesconsumer/slack/impl/SlackMessagingServiceImplTest.java
@@ -65,18 +65,18 @@ class SlackMessagingServiceImplTest {
     @Test
     void testSuccessfulDeserializationErrorMessage() throws IOException, SlackApiException {
         doReturn(buildDummyResponse(true)).when(slackMessagingServiceImpl).postSlackMessage(any(), any());
-        String errorMessage = "Failed to deserialize message - topic: Test-topic, partition: 1, offset: 1";
-        slackMessagingServiceImpl.sendDeserializationErrorMessage(errorMessage);
-        verify(logger).info(String.format("Deserialization error message sent to: %s", SLACK_CHANNEL));
+        String errorMessage = "Message rejected - Failed to deserialize message - topic: Test-topic, partition: 1, offset: 1";
+        slackMessagingServiceImpl.sendRejectedErrorMessage(errorMessage);
+        verify(logger).info(String.format("Message rejected error message sent to: %s", SLACK_CHANNEL));
     }
 
     @Test
     void testFailedSlackDeserializationErrorMessage() throws IOException, SlackApiException {
         ChatPostMessageResponse chatPostMessageResponse = buildDummyResponse(false);
         doReturn(chatPostMessageResponse).when(slackMessagingServiceImpl).postSlackMessage(any(), any());
-        String errorMessage = "Failed to deserialize message - topic: Test-topic, partition: 1, offset: 1";
-        slackMessagingServiceImpl.sendDeserializationErrorMessage(errorMessage);
-        verify(logger).error(String.format("Deserialization error message sent but received response: %s",
+        String errorMessage = "Message rejected - Failed to deserialize message - topic: Test-topic, partition: 1, offset: 1";
+        slackMessagingServiceImpl.sendRejectedErrorMessage(errorMessage);
+        verify(logger).error(String.format("Message rejected error message sent but received response: %s",
                 chatPostMessageResponse.getError()));
     }
 
@@ -84,9 +84,9 @@ class SlackMessagingServiceImplTest {
     void testFailedSlackDeserializationErrorMessageWithIOException() throws IOException, SlackApiException {
         IOException io = new IOException(null, null);
         doThrow(io).when(slackMessagingServiceImpl).postSlackMessage(any(), any());
-        String errorMessage = "Failed to deserialize message - topic: Test-topic, partition: 1, offset: 1";
-        slackMessagingServiceImpl.sendDeserializationErrorMessage(errorMessage);
-        verify(logger).errorContext("Deserialization error slack error message not sent", io);
+        String errorMessage = "Message rejected - Failed to deserialize message - topic: Test-topic, partition: 1, offset: 1";
+        slackMessagingServiceImpl.sendRejectedErrorMessage(errorMessage);
+        verify(logger).errorContext("Message rejected error slack error message not sent", io);
     }
 
     private List<String> buildDummyFailedMessages() {


### PR DESCRIPTION
…k notification

Currently only deserialisation exceptions get sent to slack by the ErrorHandler, this change is to send all exceptions from errorHandler to Slack.